### PR TITLE
Fix: Add build steps to GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,13 +26,30 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: './child-learning-app/package-lock.json'
+
+      - name: Install dependencies
+        run: |
+          cd child-learning-app
+          npm ci
+
+      - name: Build
+        run: |
+          cd child-learning-app
+          npm run build
+
       - name: Setup Pages
         uses: actions/configure-pages@v4
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: './docs'
+          path: './child-learning-app/dist'
 
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
デプロイワークフローにReactアプリのビルドステップを追加しました。

## 変更内容
- Node.js 20のセットアップ
- npm ciで依存関係インストール
- npm run buildでReactアプリをビルド
- デプロイパスを ./child-learning-app/dist に変更

これにより、GitHub PagesでReactアプリが正しく表示されるようになります。