### PR TITLE
Feature: Add quick past paper creation and improve session sorting

### DIFF
--- a/child-learning-app/src/App.jsx
+++ b/child-learning-app/src/App.jsx
@@ -431,6 +431,8 @@ function App() {
             tasks={tasks}
             user={user}
             customUnits={customUnits}
+            onAddTask={addTask}
+            onUpdateTask={updateTask}
           />
         ) : view === 'testscore' ? (
           <TestScoreView

--- a/child-learning-app/src/components/PastPaperView.css
+++ b/child-learning-app/src/components/PastPaperView.css
@@ -8,6 +8,13 @@
   margin-bottom: 30px;
 }
 
+.header-title-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 20px;
+}
+
 .view-header h2 {
   color: #1e40af;
   font-size: 1.8rem;
@@ -17,6 +24,80 @@
 .view-description {
   color: #64748b;
   font-size: 0.95rem;
+}
+
+.add-pastpaper-btn {
+  padding: 12px 24px;
+  background: linear-gradient(135deg, #1e40af 0%, #3b82f6 100%);
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 8px rgba(30, 64, 175, 0.3);
+  white-space: nowrap;
+}
+
+.add-pastpaper-btn:hover {
+  background: linear-gradient(135deg, #1e3a8a 0%, #2563eb 100%);
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(30, 64, 175, 0.4);
+}
+
+/* 過去問追加フォーム */
+.add-pastpaper-form {
+  background: white;
+  border-radius: 12px;
+  padding: 25px;
+  margin-bottom: 30px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  border: 2px solid #e0e7ff;
+}
+
+.add-pastpaper-form h3 {
+  color: #1e40af;
+  margin-bottom: 20px;
+  font-size: 1.2rem;
+}
+
+.add-form-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 15px;
+  margin-bottom: 20px;
+}
+
+.add-form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.add-form-field label {
+  font-weight: 600;
+  color: #1e293b;
+  font-size: 0.95rem;
+}
+
+.add-form-field input {
+  padding: 10px 12px;
+  border: 2px solid #e2e8f0;
+  border-radius: 8px;
+  font-size: 0.95rem;
+  transition: all 0.3s ease;
+}
+
+.add-form-field input:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.add-form-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
 }
 
 /* フィルター */
@@ -386,6 +467,19 @@
 @media (max-width: 768px) {
   .pastpaper-view {
     padding: 15px;
+  }
+
+  .header-title-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .add-pastpaper-btn {
+    width: 100%;
+  }
+
+  .add-form-grid {
+    grid-template-columns: 1fr;
   }
 
   .view-header h2 {

--- a/child-learning-app/src/components/UnitDashboard.jsx
+++ b/child-learning-app/src/components/UnitDashboard.jsx
@@ -31,16 +31,11 @@ function UnitDashboard({ tasks, onEditTask, customUnits = [] }) {
   const progress = getGradeProgress(selectedSubject, selectedGrade, currentUnits)
 
   const handleAddSession = (unitId) => {
-    console.log('=== handleAddSession 開始 ===')
-    console.log('unitId:', unitId)
-    console.log('sessionForm:', sessionForm)
-
     try {
-      const result = addStudySession({
+      addStudySession({
         unitId,
         ...sessionForm,
       })
-      console.log('保存結果:', result)
 
       setShowSessionForm(false)
       setSessionForm({
@@ -53,9 +48,7 @@ function UnitDashboard({ tasks, onEditTask, customUnits = [] }) {
       setSelectedGrade(selectedGrade)
 
       toast.success('学習記録を保存しました')
-      console.log('=== handleAddSession 完了 ===')
     } catch (error) {
-      console.error('保存エラー:', error)
       toast.error('保存に失敗しました: ' + error.message)
     }
   }


### PR DESCRIPTION
Major improvements to past paper workflow:
- Add quick creation form directly in PastPaperView
- No need to navigate to Tasks view anymore
- Simple 3-field form: school name, year, round
- Sort session list by attempt number (1st, 2nd, 3rd...)
- Clean up debug console logs from all components

UI improvements:
- New "+ 過去問を追加" button in header
- Inline form with school, year, round fields
- Responsive design for mobile devices
- Better user experience with toast notifications

Technical changes:
- Pass onAddTask and onUpdateTask to PastPaperView
- Sort sessions by attemptNumber in ascending order
- Remove console.log debugging statements
- Add comprehensive CSS for new form components