### PR TITLE
Feature: Add delete button for past paper cards

### DIFF
--- a/child-learning-app/src/App.jsx
+++ b/child-learning-app/src/App.jsx
@@ -433,6 +433,7 @@ function App() {
             customUnits={customUnits}
             onAddTask={addTask}
             onUpdateTask={updateTask}
+            onDeleteTask={deleteTask}
           />
         ) : view === 'testscore' ? (
           <TestScoreView

--- a/child-learning-app/src/components/PastPaperView.css
+++ b/child-learning-app/src/components/PastPaperView.css
@@ -252,6 +252,29 @@
   flex: 1;
 }
 
+.card-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.delete-pastpaper-btn {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 1.2rem;
+  padding: 5px 8px;
+  border-radius: 6px;
+  transition: all 0.3s ease;
+  opacity: 0.6;
+}
+
+.delete-pastpaper-btn:hover {
+  background: #fee2e2;
+  opacity: 1;
+  transform: scale(1.1);
+}
+
 .task-name {
   display: block;
   font-weight: 700;
@@ -497,6 +520,11 @@
   .card-header {
     flex-direction: column;
     gap: 10px;
+  }
+
+  .card-header-actions {
+    width: 100%;
+    justify-content: space-between;
   }
 
   .attempt-count {

--- a/child-learning-app/src/components/PastPaperView.jsx
+++ b/child-learning-app/src/components/PastPaperView.jsx
@@ -4,12 +4,13 @@ import { subjects } from '../utils/unitsDatabase'
 import {
   getSessionsByTaskId,
   addPastPaperSession,
-  getNextAttemptNumber
+  getNextAttemptNumber,
+  deleteSessionsByTaskId
 } from '../utils/pastPaperSessions'
 import { subjectColors } from '../utils/constants'
 import { toast } from '../utils/toast'
 
-function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask }) {
+function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask, onDeleteTask }) {
   const [viewMode, setViewMode] = useState('school') // 'school' or 'unit'
   const [selectedSubject, setSelectedSubject] = useState('算数')
   const [sessions, setSessions] = useState({}) // taskId -> sessions[]
@@ -171,6 +172,38 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask 
     toast.success('過去問を追加しました')
   }
 
+  // 過去問タスクを削除
+  const handleDeletePastPaper = async (taskId, taskTitle) => {
+    if (!user) {
+      toast.error('ログインが必要です')
+      return
+    }
+
+    // 確認ダイアログ
+    const confirmed = window.confirm(
+      `「${taskTitle}」を削除しますか？\n\nこの過去問に関連する学習記録もすべて削除されます。`
+    )
+
+    if (!confirmed) return
+
+    try {
+      // 先に関連するセッションデータを削除
+      const sessionResult = await deleteSessionsByTaskId(user.uid, taskId)
+
+      if (!sessionResult.success) {
+        toast.error('学習記録の削除に失敗しました: ' + sessionResult.error)
+        return
+      }
+
+      // タスクを削除
+      await onDeleteTask(taskId)
+
+      toast.success('過去問を削除しました')
+    } catch (error) {
+      toast.error('削除に失敗しました: ' + error.message)
+    }
+  }
+
   const groupedData = viewMode === 'school' ? groupBySchool() : groupByUnit()
 
   return (
@@ -317,8 +350,17 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask 
                             {task.schoolName} {task.year} {task.round}
                           </span>
                         </div>
-                        <div className="attempt-count">
-                          {taskSessions.length}回演習済み
+                        <div className="card-header-actions">
+                          <div className="attempt-count">
+                            {taskSessions.length}回演習済み
+                          </div>
+                          <button
+                            className="delete-pastpaper-btn"
+                            onClick={() => handleDeletePastPaper(task.id, task.title)}
+                            title="この過去問を削除"
+                          >
+                            🗑️
+                          </button>
                         </div>
                       </div>
 

--- a/child-learning-app/src/utils/pastPaperSessions.js
+++ b/child-learning-app/src/utils/pastPaperSessions.js
@@ -168,6 +168,40 @@ export async function deleteSession(userId, firestoreId) {
 }
 
 /**
+ * タスクに関連するすべてのセッションを削除
+ * @param {string} userId - ユーザーID
+ * @param {string} taskId - タスクID
+ * @returns {Promise<object>} 結果
+ */
+export async function deleteSessionsByTaskId(userId, taskId) {
+  try {
+    const result = await getSessionsByTaskId(userId, taskId)
+
+    if (!result.success) {
+      return result
+    }
+
+    // 全てのセッションを削除
+    const deletePromises = result.data.map(session =>
+      deleteSession(userId, session.firestoreId)
+    )
+
+    await Promise.all(deletePromises)
+
+    return {
+      success: true,
+      deletedCount: result.data.length
+    }
+  } catch (error) {
+    console.error('Error deleting sessions by task ID:', error)
+    return {
+      success: false,
+      error: error.message
+    }
+  }
+}
+
+/**
  * タスクの最新の試行回数を取得
  * @param {string} userId - ユーザーID
  * @param {string} taskId - タスクID


### PR DESCRIPTION
Allow users to delete past paper tasks directly from the cards.

Changes:
- Add deleteSessionsByTaskId function to delete all sessions for a task
- Pass onDeleteTask to PastPaperView from App.jsx
- Add delete button (🗑️) to each past paper card
- Show confirmation dialog before deletion
- Delete related session data before deleting the task
- Add CSS styling for delete button with hover effects
- Responsive design for mobile devices

User experience:
- Delete button appears on each card
- Confirmation dialog warns about session data deletion
- Success/error toast notifications
- All related learning records are removed with the task