### PR TITLE
Fix: Display unit names instead of IDs in past paper unit view

### DIFF
--- a/child-learning-app/src/components/PastPaperView.jsx
+++ b/child-learning-app/src/components/PastPaperView.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, useCallback } from 'react'
 import './PastPaperView.css'
-import { subjects } from '../utils/unitsDatabase'
+import { subjects, unitsDatabase } from '../utils/unitsDatabase'
 import {
   getSessionsByTaskId,
   addPastPaperSession,
@@ -94,6 +94,19 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
     // customUnitsから検索
     const customUnit = customUnits.find(u => u.id === unitId)
     if (customUnit) return customUnit.name
+
+    // unitsDatabaseから検索
+    for (const subject of subjects) {
+      const gradeData = unitsDatabase[subject]
+      if (gradeData) {
+        for (const grade in gradeData) {
+          const units = gradeData[grade]
+          const unit = units.find(u => u.id === unitId)
+          if (unit) return unit.name
+        }
+      }
+    }
+
     return unitId
   }
 


### PR DESCRIPTION
When viewing past papers grouped by unit, show readable unit names instead of internal IDs like 'math4_01'.

Changes:
- Import unitsDatabase in PastPaperView
- Enhance getUnitName function to search both custom units and unitsDatabase
- Now displays '四則計算の基礎' instead of 'math4_01'
- Falls back to unit ID if name not found

User experience:
- Unit names are now readable and understandable
- Works for both default units and custom units
- Better clarity when organizing past papers by unit