### PR TITLE
Feature: Auto-cleanup deleted custom unit references in past papers

### DIFF
--- a/child-learning-app/src/components/PastPaperView.jsx
+++ b/child-learning-app/src/components/PastPaperView.jsx
@@ -75,6 +75,43 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
     loadSessions()
   }, [loadSessions])
 
+  // 削除されたカスタム単元への参照をクリーンアップ
+  useEffect(() => {
+    if (!user || !onUpdateTask) return
+
+    // customUnitsに存在しないIDを持つrelatedUnitsを持つタスクを探す
+    const customUnitIds = customUnits.map(u => u.id)
+
+    pastPaperTasks.forEach(task => {
+      if (task.relatedUnits && task.relatedUnits.length > 0) {
+        // 存在しないカスタム単元への参照を削除
+        const invalidUnits = task.relatedUnits.filter(unitId => {
+          // カスタム単元IDの場合のみチェック
+          if (unitId.startsWith('custom_')) {
+            return !customUnitIds.includes(unitId)
+          }
+          return false
+        })
+
+        if (invalidUnits.length > 0) {
+          console.warn(`⚠️ タスク「${task.title}」に削除された単元への参照があります:`, invalidUnits)
+
+          // 有効な単元IDのみ残す
+          const validUnits = task.relatedUnits.filter(unitId => !invalidUnits.includes(unitId))
+
+          console.log(`🔧 修正中: relatedUnitsを更新`, {
+            before: task.relatedUnits,
+            after: validUnits
+          })
+
+          // タスクを更新
+          onUpdateTask(task.id, { relatedUnits: validUnits })
+          toast.info(`「${task.title}」の削除された単元への参照を修正しました`)
+        }
+      }
+    })
+  }, [user, pastPaperTasks, customUnits, onUpdateTask])
+
   // 学校別にグループ化
   const groupBySchool = () => {
     const grouped = {}


### PR DESCRIPTION
Automatically remove references to deleted custom units from past paper tasks.

Problem identified from debug logs:
- Task '切断' had relatedUnits: ['math4_04', 'custom_math6_1764916710222']
- custom_math6_1764916710222 was deleted but reference remained
- This caused the unit ID to display instead of a readable name

Solution:
- Add useEffect that checks all past paper tasks on mount
- Detect custom unit IDs (starting with 'custom_') that no longer exist
- Automatically remove invalid references from relatedUnits
- Update tasks in Firestore
- Show toast notification when cleanup occurs

Benefits:
- Cleans up data automatically when viewing past papers
- Prevents confusing unit IDs from displaying
- Unit view count now matches school view count
- No manual intervention required