### PR TITLE
Feature: タスクと過去問を独立させ、過去問に編集機能を追加

### DIFF
--- a/child-learning-app/src/components/PastPaperView.css
+++ b/child-learning-app/src/components/PastPaperView.css
@@ -393,6 +393,23 @@
   gap: 10px;
 }
 
+.edit-pastpaper-btn {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 1.2rem;
+  padding: 5px 8px;
+  border-radius: 6px;
+  transition: all 0.3s ease;
+  opacity: 0.6;
+}
+
+.edit-pastpaper-btn:hover {
+  background: #dbeafe;
+  opacity: 1;
+  transform: scale(1.1);
+}
+
 .delete-pastpaper-btn {
   background: transparent;
   border: none;
@@ -621,6 +638,63 @@
   box-shadow: 0 4px 12px rgba(16, 185, 129, 0.4);
 }
 
+/* 編集フォーム */
+.edit-form-container {
+  padding: 15px;
+}
+
+.edit-form-container h4 {
+  color: #1e40af;
+  margin-bottom: 15px;
+  font-size: 1.1rem;
+}
+
+.edit-form-section {
+  margin-top: 15px;
+  padding-top: 15px;
+  border-top: 1px solid #fef3c7;
+}
+
+.edit-form-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+  margin-bottom: 15px;
+}
+
+.edit-form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.edit-form-field label {
+  font-weight: 600;
+  color: #1e293b;
+  font-size: 0.9rem;
+}
+
+.edit-form-field input {
+  padding: 8px 10px;
+  border: 2px solid #e2e8f0;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  transition: all 0.3s ease;
+}
+
+.edit-form-field input:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.edit-form-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  margin-top: 15px;
+}
+
 /* レスポンシブ */
 @media (max-width: 768px) {
   .pastpaper-view {
@@ -637,6 +711,10 @@
   }
 
   .add-form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .edit-form-grid {
     grid-template-columns: 1fr;
   }
 

--- a/child-learning-app/src/components/TaskList.jsx
+++ b/child-learning-app/src/components/TaskList.jsx
@@ -21,6 +21,9 @@ function TaskList({ tasks, onToggleTask, onDeleteTask, onBulkDeleteTasks, onEdit
   const filteredAndSortedTasks = useMemo(() => {
     let result = [...tasks]
 
+    // 過去問タスクを除外（過去問ビューで管理）
+    result = result.filter(task => task.taskType !== 'pastpaper')
+
     // 科目フィルター
     if (selectedSubject !== '全て') {
       result = result.filter(task => task.subject === selectedSubject)
@@ -57,16 +60,17 @@ function TaskList({ tasks, onToggleTask, onDeleteTask, onBulkDeleteTasks, onEdit
     return result
   }, [tasks, searchQuery, sortBy, selectedSubject])
 
-  // 統計を計算
+  // 統計を計算（過去問を除外）
   const statistics = useMemo(() => {
-    const total = tasks.length
-    const completed = tasks.filter(t => t.completed).length
+    const nonPastPaperTasks = tasks.filter(t => t.taskType !== 'pastpaper')
+    const total = nonPastPaperTasks.length
+    const completed = nonPastPaperTasks.filter(t => t.completed).length
     const pending = total - completed
     const completionRate = total > 0 ? Math.round((completed / total) * 100) : 0
 
     // 科目別統計
     const bySubject = {}
-    tasks.forEach(task => {
+    nonPastPaperTasks.forEach(task => {
       const subject = task.subject || 'その他'
       if (!bySubject[subject]) {
         bySubject[subject] = { total: 0, completed: 0 }
@@ -77,7 +81,7 @@ function TaskList({ tasks, onToggleTask, onDeleteTask, onBulkDeleteTasks, onEdit
 
     // 優先度別統計
     const byPriority = {}
-    tasks.forEach(task => {
+    nonPastPaperTasks.forEach(task => {
       const priority = task.priority || 'なし'
       if (!byPriority[priority]) {
         byPriority[priority] = { total: 0, completed: 0 }


### PR DESCRIPTION
問題:
- タスクビューで過去問タスクを編集するとtaskTypeを変更でき、過去問ビューから消えてしまう

解決:
1. タスクビューから過去問タスク（taskType: 'pastpaper'）を完全に除外
   - フィルタリングと統計計算から除外
   - 過去問は過去問ビューでのみ管理

2. 過去問ビューに編集機能を追加
   - 各カードに編集ボタン（✏️）を追加
   - 編集フォームで学校名、年度、回、科目、関連単元を変更可能
   - 科目変更時に関連単元を自動クリア
   - 編集中は学習記録の表示/追加を非表示

実装内容:
- TaskList.jsx: 過去問タスクをフィルタリングと統計から除外
- PastPaperView.jsx: 編集機能の追加（state、ハンドラー、UI）
- PastPaperView.css: 編集ボタンと編集フォームのスタイリング