### PR TITLE
Fix: 過去問フォームのレイアウト崩れを修正

### DIFF
--- a/child-learning-app/src/components/PastPaperView.css
+++ b/child-learning-app/src/components/PastPaperView.css
@@ -63,7 +63,7 @@
 
 .add-form-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: 1fr;
   gap: 15px;
   margin-bottom: 20px;
 }
@@ -657,7 +657,7 @@
 
 .edit-form-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: 1fr;
   gap: 12px;
   margin-bottom: 15px;
 }


### PR DESCRIPTION
問題:
- 追加フォームと編集フォームで学校名、年度、回がはみ出していた

解決:
- add-form-gridを3カラムから1カラムに変更
- edit-form-gridを3カラムから1カラムに変更
- 縦に並ぶことではみ出しを防止