### PR TITLE
Fix: 過去問フォームで年度と回を横並びに変更

### DIFF
--- a/child-learning-app/src/components/PastPaperView.css
+++ b/child-learning-app/src/components/PastPaperView.css
@@ -61,9 +61,9 @@
   font-size: 1.2rem;
 }
 
-.add-form-grid {
+.add-form-grid-two-cols {
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: 1fr 1fr;
   gap: 15px;
   margin-bottom: 20px;
 }
@@ -655,9 +655,9 @@
   border-top: 1px solid #fef3c7;
 }
 
-.edit-form-grid {
+.edit-form-grid-two-cols {
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: 1fr 1fr;
   gap: 12px;
   margin-bottom: 15px;
 }
@@ -710,11 +710,11 @@
     width: 100%;
   }
 
-  .add-form-grid {
+  .add-form-grid-two-cols {
     grid-template-columns: 1fr;
   }
 
-  .edit-form-grid {
+  .edit-form-grid-two-cols {
     grid-template-columns: 1fr;
   }
 

--- a/child-learning-app/src/components/PastPaperView.jsx
+++ b/child-learning-app/src/components/PastPaperView.jsx
@@ -435,16 +435,17 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
             </div>
           </div>
 
-          <div className="add-form-grid">
-            <div className="add-form-field">
-              <label>学校名:</label>
-              <input
-                type="text"
-                placeholder="例: 開成中学校"
-                value={addForm.schoolName}
-                onChange={(e) => setAddForm({ ...addForm, schoolName: e.target.value })}
-              />
-            </div>
+          <div className="add-form-field" style={{ marginBottom: '15px' }}>
+            <label>学校名:</label>
+            <input
+              type="text"
+              placeholder="例: 開成中学校"
+              value={addForm.schoolName}
+              onChange={(e) => setAddForm({ ...addForm, schoolName: e.target.value })}
+            />
+          </div>
+
+          <div className="add-form-grid-two-cols">
             <div className="add-form-field">
               <label>年度:</label>
               <input
@@ -635,15 +636,16 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
                             </div>
                           </div>
 
-                          <div className="edit-form-grid">
-                            <div className="edit-form-field">
-                              <label>学校名:</label>
-                              <input
-                                type="text"
-                                value={editForm.schoolName}
-                                onChange={(e) => setEditForm({ ...editForm, schoolName: e.target.value })}
-                              />
-                            </div>
+                          <div className="edit-form-field" style={{ marginBottom: '15px' }}>
+                            <label>学校名:</label>
+                            <input
+                              type="text"
+                              value={editForm.schoolName}
+                              onChange={(e) => setEditForm({ ...editForm, schoolName: e.target.value })}
+                            />
+                          </div>
+
+                          <div className="edit-form-grid-two-cols">
                             <div className="edit-form-field">
                               <label>年度:</label>
                               <input


### PR DESCRIPTION
変更内容:
- 学校名：1行で全幅使用
- 年度と回：2カラムグリッドで横並び
- 追加フォームと編集フォームの両方に適用
- モバイル表示時は縦並びに切り替わるレスポンシブ対応