### PR TITLE
Feature: 過去問カードに関連単元を表示

### DIFF
--- a/child-learning-app/src/components/PastPaperView.css
+++ b/child-learning-app/src/components/PastPaperView.css
@@ -451,6 +451,37 @@
   white-space: nowrap;
 }
 
+/* 関連単元 */
+.related-units {
+  margin-top: 12px;
+  margin-bottom: 12px;
+}
+
+.related-units-label {
+  display: block;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #64748b;
+  margin-bottom: 8px;
+}
+
+.related-units-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.unit-tag {
+  display: inline-block;
+  background: #dbeafe;
+  color: #1e40af;
+  padding: 4px 10px;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  border: 1px solid #bfdbfe;
+}
+
 /* 最新セッション */
 .last-session {
   display: flex;

--- a/child-learning-app/src/components/PastPaperView.jsx
+++ b/child-learning-app/src/components/PastPaperView.jsx
@@ -754,6 +754,20 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
                               </button>
                             </div>
                           </div>
+
+                          {/* 関連単元の表示 */}
+                          {task.relatedUnits && task.relatedUnits.length > 0 && (
+                            <div className="related-units">
+                              <span className="related-units-label">📚 関連単元:</span>
+                              <div className="related-units-tags">
+                                {task.relatedUnits.map(unitId => (
+                                  <span key={unitId} className="unit-tag">
+                                    {getUnitName(unitId)}
+                                  </span>
+                                ))}
+                              </div>
+                            </div>
+                          )}
                         </>
                       )}
 


### PR DESCRIPTION
問題:
- 学校別表示時に過去問の関連単元が確認できなかった

解決:
- 各過去問カードに関連単元を表示
- 単元名をタグ形式で表示（青色バッジ）
- カードヘッダーの直下に配置
- 単元が設定されていない場合は非表示

実装内容:
- PastPaperView.jsx: 関連単元の表示ロジック追加
- PastPaperView.css: 単元タグのスタイリング追加