### PR TITLE
Feature: 過去問カードにファイルリンク機能を追加

### DIFF
--- a/child-learning-app/src/components/PastPaperView.css
+++ b/child-learning-app/src/components/PastPaperView.css
@@ -114,6 +114,30 @@
   margin-bottom: 12px;
 }
 
+/* 問題ファイルURL入力 */
+.file-url-input {
+  width: 100%;
+  padding: 10px 12px;
+  border: 2px solid #e2e8f0;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  transition: all 0.3s ease;
+  margin-bottom: 8px;
+}
+
+.file-url-input:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.input-hint {
+  display: block;
+  color: #64748b;
+  font-size: 0.8rem;
+  font-style: italic;
+}
+
 /* 科目選択（フォーム内） */
 .subject-selector-inline {
   display: flex;
@@ -391,6 +415,26 @@
   display: flex;
   align-items: center;
   gap: 10px;
+}
+
+.file-link-btn {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 1.2rem;
+  padding: 5px 8px;
+  border-radius: 6px;
+  transition: all 0.3s ease;
+  opacity: 0.6;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+}
+
+.file-link-btn:hover {
+  background: #fef3c7;
+  opacity: 1;
+  transform: scale(1.1);
 }
 
 .edit-pastpaper-btn {

--- a/child-learning-app/src/components/PastPaperView.jsx
+++ b/child-learning-app/src/components/PastPaperView.jsx
@@ -29,7 +29,8 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
     round: '',
     subject: '算数',  // フォーム内で独立して科目を管理
     grade: '4年生',
-    relatedUnits: []
+    relatedUnits: [],
+    fileUrl: ''  // GoogleドライブやPDFのURL
   })
   const [editingTaskId, setEditingTaskId] = useState(null) // 編集中の過去問タスクID
   const [editForm, setEditForm] = useState({
@@ -38,7 +39,8 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
     round: '',
     subject: '算数',
     grade: '4年生',
-    relatedUnits: []
+    relatedUnits: [],
+    fileUrl: ''  // GoogleドライブやPDFのURL
   })
 
   // 過去問タスクのみフィルタリング（学年無関係）
@@ -276,12 +278,13 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
       year: addForm.year,
       round: addForm.round,
       relatedUnits: addForm.relatedUnits,
+      fileUrl: addForm.fileUrl,  // 問題ファイルのURL
       dueDate: '',
       priority: 'medium'
     }
 
     await onAddTask(newTask)
-    setAddForm({ schoolName: '', year: '', round: '', subject: '算数', grade: '4年生', relatedUnits: [] })
+    setAddForm({ schoolName: '', year: '', round: '', subject: '算数', grade: '4年生', relatedUnits: [], fileUrl: '' })
     setShowAddForm(false)
     toast.success('過去問を追加しました')
   }
@@ -327,7 +330,8 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
       round: task.round || '',
       subject: task.subject || '算数',
       grade: task.grade || '4年生',
-      relatedUnits: task.relatedUnits || []
+      relatedUnits: task.relatedUnits || [],
+      fileUrl: task.fileUrl || ''
     })
   }
 
@@ -340,7 +344,8 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
       round: '',
       subject: '算数',
       grade: '4年生',
-      relatedUnits: []
+      relatedUnits: [],
+      fileUrl: ''
     })
   }
 
@@ -357,7 +362,8 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
       year: editForm.year,
       round: editForm.round,
       subject: editForm.subject,
-      relatedUnits: editForm.relatedUnits
+      relatedUnits: editForm.relatedUnits,
+      fileUrl: editForm.fileUrl
     }
 
     await onUpdateTask(editingTaskId, updatedTask)
@@ -466,6 +472,21 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
             </div>
           </div>
 
+          {/* 問題ファイルURL */}
+          <div className="add-form-section">
+            <label className="section-label">📎 問題ファイル（任意）:</label>
+            <input
+              type="url"
+              className="file-url-input"
+              placeholder="GoogleドライブやPDFのURLを貼り付け"
+              value={addForm.fileUrl}
+              onChange={(e) => setAddForm({ ...addForm, fileUrl: e.target.value })}
+            />
+            <small className="input-hint">
+              Googleドライブの共有リンクやPDFのURLを入力してください
+            </small>
+          </div>
+
           {/* 学年選択 */}
           <div className="add-form-section">
             <label className="section-label">学年（単元選択用）:</label>
@@ -524,7 +545,7 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
               className="btn-secondary"
               onClick={() => {
                 setShowAddForm(false)
-                setAddForm({ schoolName: '', year: '', round: '', subject: '算数', grade: '4年生', relatedUnits: [] })
+                setAddForm({ schoolName: '', year: '', round: '', subject: '算数', grade: '4年生', relatedUnits: [], fileUrl: '' })
               }}
             >
               キャンセル
@@ -664,6 +685,21 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
                             </div>
                           </div>
 
+                          {/* 問題ファイルURL */}
+                          <div className="edit-form-section">
+                            <label className="section-label">📎 問題ファイル（任意）:</label>
+                            <input
+                              type="url"
+                              className="file-url-input"
+                              placeholder="GoogleドライブやPDFのURLを貼り付け"
+                              value={editForm.fileUrl}
+                              onChange={(e) => setEditForm({ ...editForm, fileUrl: e.target.value })}
+                            />
+                            <small className="input-hint">
+                              Googleドライブの共有リンクやPDFのURLを入力してください
+                            </small>
+                          </div>
+
                           {/* 学年選択 */}
                           <div className="edit-form-section">
                             <label className="section-label">学年（単元選択用）:</label>
@@ -738,6 +774,17 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
                               <div className="attempt-count">
                                 {taskSessions.length}回演習済み
                               </div>
+                              {task.fileUrl && (
+                                <a
+                                  href={task.fileUrl}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="file-link-btn"
+                                  title="問題ファイルを開く"
+                                >
+                                  📎
+                                </a>
+                              )}
                               <button
                                 className="edit-pastpaper-btn"
                                 onClick={() => handleStartEdit(task)}


### PR DESCRIPTION
機能概要:
- 過去問にGoogleドライブやPDFのURLを登録可能
- カードに📎アイコンを表示し、クリックで新しいタブで開く

実装内容:
1. データモデル
   - addForm/editFormにfileUrlフィールドを追加
   - handleAddPastPaperでfileUrlを保存
   - handleStartEdit/handleSaveEditでfileUrlを編集

2. UI追加
   - 追加フォームにURL入力欄を追加（任意項目）
   - 編集フォームにURL入力欄を追加（任意項目）
   - カードヘッダーに📎リンクボタンを追加（URLがある場合のみ表示）

3. スタイリング
   - file-url-input: URL入力欄のスタイル
   - input-hint: 入力欄のヒントテキスト
   - file-link-btn: ファイルリンクボタン（黄色ホバー）

使い方:
1. Googleドライブで共有リンクを取得
2. 過去問追加/編集時にURLを入力
3. カードの📎アイコンをクリックで開く