### PR TITLE
Fix: 過去問カードの学校名・年度・回の重複表示を修正

### DIFF
--- a/child-learning-app/src/components/PastPaperView.jsx
+++ b/child-learning-app/src/components/PastPaperView.jsx
@@ -766,9 +766,6 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
                           <div className="card-header">
                             <div className="task-title">
                               <span className="task-name">{task.title}</span>
-                              <span className="task-details">
-                                {task.schoolName} {task.year} {task.round}
-                              </span>
                             </div>
                             <div className="card-header-actions">
                               <div className="attempt-count">


### PR DESCRIPTION
問題:
- task.titleとtask-detailsで同じ情報が2段に表示されていた

解決:
- task-detailsの重複表示を削除
- task.titleのみを表示するように変更