### PR TITLE
UI: 過去問カードの縦方向をさらにコンパクトに

### DIFF
--- a/child-learning-app/src/components/PastPaperView.css
+++ b/child-learning-app/src/components/PastPaperView.css
@@ -389,7 +389,7 @@
   background: #fefce8;
   border: 2px solid #fde047;
   border-radius: 8px;
-  padding: 12px;
+  padding: 8px;
   transition: all 0.3s ease;
 }
 
@@ -401,9 +401,9 @@
 .card-header {
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
-  margin-bottom: 10px;
-  padding-bottom: 10px;
+  align-items: center;
+  margin-bottom: 6px;
+  padding-bottom: 6px;
   border-bottom: 1px solid #fef3c7;
 }
 
@@ -414,16 +414,16 @@
 .card-header-actions {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 4px;
 }
 
 .file-link-btn {
   background: transparent;
   border: none;
   cursor: pointer;
-  font-size: 1.2rem;
-  padding: 5px 8px;
-  border-radius: 6px;
+  font-size: 1rem;
+  padding: 3px 5px;
+  border-radius: 4px;
   transition: all 0.3s ease;
   opacity: 0.6;
   text-decoration: none;
@@ -441,9 +441,9 @@
   background: transparent;
   border: none;
   cursor: pointer;
-  font-size: 1.2rem;
-  padding: 5px 8px;
-  border-radius: 6px;
+  font-size: 1rem;
+  padding: 3px 5px;
+  border-radius: 4px;
   transition: all 0.3s ease;
   opacity: 0.6;
 }
@@ -458,9 +458,9 @@
   background: transparent;
   border: none;
   cursor: pointer;
-  font-size: 1.2rem;
-  padding: 5px 8px;
-  border-radius: 6px;
+  font-size: 1rem;
+  padding: 3px 5px;
+  border-radius: 4px;
   transition: all 0.3s ease;
   opacity: 0.6;
 }
@@ -475,8 +475,9 @@
   display: block;
   font-weight: 700;
   color: #1e293b;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   margin-bottom: 0;
+  line-height: 1.3;
 }
 
 .task-details {
@@ -488,17 +489,17 @@
 .attempt-count {
   background: #fbbf24;
   color: white;
-  padding: 3px 10px;
-  border-radius: 12px;
-  font-size: 0.75rem;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 0.7rem;
   font-weight: 600;
   white-space: nowrap;
 }
 
 /* 関連単元 */
 .related-units {
-  margin-top: 8px;
-  margin-bottom: 8px;
+  margin-top: 4px;
+  margin-bottom: 4px;
 }
 
 .related-units-label {
@@ -530,12 +531,12 @@
 .last-session {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 6px 10px;
+  gap: 6px;
+  padding: 4px 8px;
   background: white;
-  border-radius: 6px;
-  margin-bottom: 8px;
-  font-size: 0.8rem;
+  border-radius: 4px;
+  margin-bottom: 4px;
+  font-size: 0.75rem;
 }
 
 .session-label {
@@ -551,34 +552,34 @@
   margin-left: auto;
   background: #10b981;
   color: white;
-  padding: 2px 8px;
-  border-radius: 6px;
+  padding: 2px 6px;
+  border-radius: 4px;
   font-weight: 600;
-  font-size: 0.75rem;
+  font-size: 0.7rem;
 }
 
 /* セッション一覧 */
 .sessions-list {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  margin-bottom: 10px;
+  gap: 4px;
+  margin-bottom: 6px;
 }
 
 .session-item {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 6px 10px;
+  gap: 6px;
+  padding: 4px 8px;
   background: white;
   border-radius: 4px;
-  font-size: 0.75rem;
+  font-size: 0.7rem;
 }
 
 .session-attempt {
   font-weight: 600;
   color: #1e40af;
-  min-width: 45px;
+  min-width: 40px;
 }
 
 .session-time {


### PR DESCRIPTION
変更内容:
1. カード全体をコンパクトに
   - padding: 12px → 8px
   - card-header margin/padding: 10px → 6px
   - align-items: flex-start → center (横一列に)

2. アイコンとボタンを小さく
   - font-size: 1.2rem → 1rem
   - padding: 5px 8px → 3px 5px
   - gap: 10px → 4px
   - 演習済み: padding 3px 10px → 2px 8px

3. フォントサイズを縮小
   - task-name: 0.95rem → 0.9rem
   - attempt-count: 0.75rem → 0.7rem
   - セッション表示: 0.8rem → 0.75rem

4. 余白を全体的に削減
   - related-units: 8px → 4px
   - last-session: padding 6px 10px → 4px 8px
   - sessions-list: gap 6px → 4px
   - session-item: padding 6px 10px → 4px 8px

結果: 縦方向が大幅にコンパクトになり、より多くのカードを表示可能