### PR TITLE
UI: iPhone対応で上半分をさらにコンパクトに

### DIFF
--- a/child-learning-app/src/components/PastPaperView.css
+++ b/child-learning-app/src/components/PastPaperView.css
@@ -381,15 +381,15 @@
 /* タスクカード */
 .task-cards {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
-  gap: 15px;
+  grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+  gap: 12px;
 }
 
 .pastpaper-card {
   background: #fefce8;
   border: 2px solid #fde047;
   border-radius: 8px;
-  padding: 8px;
+  padding: 6px;
   transition: all 0.3s ease;
 }
 
@@ -402,8 +402,8 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 6px;
-  padding-bottom: 6px;
+  margin-bottom: 4px;
+  padding-bottom: 4px;
   border-bottom: 1px solid #fef3c7;
 }
 
@@ -414,15 +414,15 @@
 .card-header-actions {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 3px;
 }
 
 .file-link-btn {
   background: transparent;
   border: none;
   cursor: pointer;
-  font-size: 1rem;
-  padding: 3px 5px;
+  font-size: 0.9rem;
+  padding: 2px 4px;
   border-radius: 4px;
   transition: all 0.3s ease;
   opacity: 0.6;
@@ -441,8 +441,8 @@
   background: transparent;
   border: none;
   cursor: pointer;
-  font-size: 1rem;
-  padding: 3px 5px;
+  font-size: 0.9rem;
+  padding: 2px 4px;
   border-radius: 4px;
   transition: all 0.3s ease;
   opacity: 0.6;
@@ -458,8 +458,8 @@
   background: transparent;
   border: none;
   cursor: pointer;
-  font-size: 1rem;
-  padding: 3px 5px;
+  font-size: 0.9rem;
+  padding: 2px 4px;
   border-radius: 4px;
   transition: all 0.3s ease;
   opacity: 0.6;
@@ -475,9 +475,9 @@
   display: block;
   font-weight: 700;
   color: #1e293b;
-  font-size: 0.9rem;
+  font-size: 0.85rem;
   margin-bottom: 0;
-  line-height: 1.3;
+  line-height: 1.2;
 }
 
 .task-details {
@@ -489,40 +489,40 @@
 .attempt-count {
   background: #fbbf24;
   color: white;
-  padding: 2px 8px;
-  border-radius: 10px;
-  font-size: 0.7rem;
+  padding: 2px 6px;
+  border-radius: 8px;
+  font-size: 0.65rem;
   font-weight: 600;
   white-space: nowrap;
 }
 
 /* 関連単元 */
 .related-units {
-  margin-top: 4px;
-  margin-bottom: 4px;
+  margin-top: 3px;
+  margin-bottom: 3px;
 }
 
 .related-units-label {
   display: inline;
-  font-size: 0.75rem;
+  font-size: 0.7rem;
   font-weight: 600;
   color: #64748b;
-  margin-right: 6px;
+  margin-right: 4px;
 }
 
 .related-units-tags {
   display: inline-flex;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: 3px;
 }
 
 .unit-tag {
   display: inline-block;
   background: #dbeafe;
   color: #1e40af;
-  padding: 2px 8px;
-  border-radius: 4px;
-  font-size: 0.7rem;
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-size: 0.65rem;
   font-weight: 500;
   border: 1px solid #bfdbfe;
 }
@@ -531,12 +531,12 @@
 .last-session {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 4px 8px;
+  gap: 4px;
+  padding: 3px 6px;
   background: white;
-  border-radius: 4px;
-  margin-bottom: 4px;
-  font-size: 0.75rem;
+  border-radius: 3px;
+  margin-bottom: 3px;
+  font-size: 0.7rem;
 }
 
 .session-label {
@@ -552,34 +552,34 @@
   margin-left: auto;
   background: #10b981;
   color: white;
-  padding: 2px 6px;
-  border-radius: 4px;
+  padding: 1px 5px;
+  border-radius: 3px;
   font-weight: 600;
-  font-size: 0.7rem;
+  font-size: 0.65rem;
 }
 
 /* セッション一覧 */
 .sessions-list {
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  margin-bottom: 6px;
+  gap: 3px;
+  margin-bottom: 4px;
 }
 
 .session-item {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 4px 8px;
+  gap: 4px;
+  padding: 3px 6px;
   background: white;
-  border-radius: 4px;
-  font-size: 0.7rem;
+  border-radius: 3px;
+  font-size: 0.65rem;
 }
 
 .session-attempt {
   font-weight: 600;
   color: #1e40af;
-  min-width: 40px;
+  min-width: 35px;
 }
 
 .session-time {


### PR DESCRIPTION
変更内容（特に上半分を重点的に縮小）:
1. カード全体
   - padding: 8px → 6px
   - gap: 15px → 12px
   - min-width: 380px → 350px

2. カードヘッダー
   - margin-bottom: 6px → 4px
   - padding-bottom: 6px → 4px

3. タスク名と演習済みバッジ
   - task-name: 0.9rem → 0.85rem, line-height: 1.3 → 1.2
   - attempt-count: 0.7rem → 0.65rem, padding: 2px 8px → 2px 6px

4. アイコン類
   - font-size: 1rem → 0.9rem
   - padding: 3px 5px → 2px 4px
   - gap: 4px → 3px

5. 関連単元
   - label: 0.75rem → 0.7rem
   - unit-tag: 0.7rem → 0.65rem, padding: 2px 8px → 1px 6px
   - margin: 4px → 3px, gap: 4px → 3px

6. セッション表示
   - last-session: padding 4px 8px → 3px 6px, 0.75rem → 0.7rem
   - session-item: padding 4px 8px → 3px 6px, 0.7rem → 0.65rem
   - session-score: 0.7rem → 0.65rem
   - gap: 6px → 4px, margin-bottom: 4px → 3px

結果: iPhone表示での上半分の高さが大幅に削減