### PR TITLE
Fix: 過去問編集フォームのレイアウトを修正

### DIFF
--- a/child-learning-app/src/components/PastPaperView.css
+++ b/child-learning-app/src/components/PastPaperView.css
@@ -716,59 +716,59 @@
 
 /* 編集フォーム */
 .edit-form-container {
-  padding: 15px;
+  padding: 8px;
 }
 
 .edit-form-container h4 {
   color: #1e40af;
-  margin-bottom: 15px;
-  font-size: 1.1rem;
+  margin-bottom: 8px;
+  font-size: 0.9rem;
 }
 
 .edit-form-section {
-  margin-top: 15px;
-  padding-top: 15px;
+  margin-top: 8px;
+  padding-top: 8px;
   border-top: 1px solid #fef3c7;
 }
 
 .edit-form-grid-two-cols {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 12px;
-  margin-bottom: 15px;
+  gap: 8px;
+  margin-bottom: 8px;
 }
 
 .edit-form-field {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 4px;
 }
 
 .edit-form-field label {
   font-weight: 600;
   color: #1e293b;
-  font-size: 0.9rem;
+  font-size: 0.75rem;
 }
 
 .edit-form-field input {
-  padding: 8px 10px;
+  padding: 6px 8px;
   border: 2px solid #e2e8f0;
-  border-radius: 6px;
-  font-size: 0.9rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
   transition: all 0.3s ease;
 }
 
 .edit-form-field input:focus {
   outline: none;
   border-color: #3b82f6;
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.1);
 }
 
 .edit-form-actions {
   display: flex;
-  gap: 10px;
+  gap: 6px;
   justify-content: flex-end;
-  margin-top: 15px;
+  margin-top: 8px;
 }
 
 /* レスポンシブ */

--- a/child-learning-app/src/components/PastPaperView.jsx
+++ b/child-learning-app/src/components/PastPaperView.jsx
@@ -441,7 +441,7 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
             </div>
           </div>
 
-          <div className="add-form-field" style={{ marginBottom: '15px' }}>
+          <div className="add-form-field" style={{ marginBottom: '8px' }}>
             <label>学校名:</label>
             <input
               type="text"
@@ -657,7 +657,7 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
                             </div>
                           </div>
 
-                          <div className="edit-form-field" style={{ marginBottom: '15px' }}>
+                          <div className="edit-form-field" style={{ marginBottom: '8px' }}>
                             <label>学校名:</label>
                             <input
                               type="text"


### PR DESCRIPTION
- 編集フォームのパディング・マージンを15px→8pxに縮小
- フォントサイズを縮小（タイトル:0.9rem、ラベル:0.75rem、入力:0.8rem）
- 入力フィールドのパディングを6px 8pxに縮小
- カードのコンパクトなデザインに合わせてすべてのスペーシングを調整
- インラインスタイルのmarginBottomを15px→8pxに統一