### PR TITLE
Fix: CSSセレクタ:has()を使わずに3列グリッドを実装

### DIFF
--- a/child-learning-app/src/components/PastPaperFields.jsx
+++ b/child-learning-app/src/components/PastPaperFields.jsx
@@ -13,8 +13,8 @@ function PastPaperFields({
 }) {
   return (
     <div className="pastpaper-fields">
-      <div className="form-row">
-        <div className="form-group third">
+      <div className="form-row three-cols">
+        <div className="form-group">
           <label htmlFor="schoolName">学校名</label>
           <input
             type="text"
@@ -24,7 +24,7 @@ function PastPaperFields({
             placeholder="例: 開成"
           />
         </div>
-        <div className="form-group third">
+        <div className="form-group">
           <label htmlFor="year">年度</label>
           <input
             type="text"
@@ -34,7 +34,7 @@ function PastPaperFields({
             placeholder="例: 2023"
           />
         </div>
-        <div className="form-group third">
+        <div className="form-group">
           <label htmlFor="round">回次</label>
           <select
             id="round"

--- a/child-learning-app/src/components/TaskForm.css
+++ b/child-learning-app/src/components/TaskForm.css
@@ -23,21 +23,18 @@
   margin-bottom: 20px;
 }
 
-.form-group {
-  margin-bottom: 20px;
+.form-row.three-cols {
+  grid-template-columns: 1fr 1fr 1fr;
+}
+
+.form-row .form-group {
+  margin-bottom: 0;
   min-width: 0;
 }
 
-.form-group.half {
-  margin-bottom: 0;
-}
-
-.form-group.third {
-  margin-bottom: 0;
-}
-
-.form-row:has(.third) {
-  grid-template-columns: 1fr 1fr 1fr;
+.form-group {
+  margin-bottom: 20px;
+  min-width: 0;
 }
 
 .form-group label {

--- a/child-learning-app/src/components/TaskForm.jsx
+++ b/child-learning-app/src/components/TaskForm.jsx
@@ -191,8 +191,8 @@ function TaskForm({ onAddTask, onUpdateTask, editingTask, onCancelEdit, customUn
     <form className="task-form sapix-form" onSubmit={handleSubmit}>
       <h2>{editingTask ? '✏️ タスクを編集' : '✏️ 学習タスクを追加'}</h2>
 
-      <div className="form-row">
-        <div className="form-group third">
+      <div className="form-row three-cols">
+        <div className="form-group">
           <label htmlFor="subject">科目</label>
           <select
             id="subject"
@@ -208,7 +208,7 @@ function TaskForm({ onAddTask, onUpdateTask, editingTask, onCancelEdit, customUn
           </select>
         </div>
 
-        <div className="form-group third">
+        <div className="form-group">
           <label htmlFor="grade">学年</label>
           <select
             id="grade"
@@ -224,7 +224,7 @@ function TaskForm({ onAddTask, onUpdateTask, editingTask, onCancelEdit, customUn
           </select>
         </div>
 
-        <div className="form-group third">
+        <div className="form-group">
           <label htmlFor="unit">単元</label>
           <div className="unit-select-container">
             <select


### PR DESCRIPTION
- :has()セレクタは古いブラウザでサポートされていない可能性があるため削除
- form-rowに.three-colsクラスを追加して明示的に3列グリッドを指定
- TaskForm.jsxとPastPaperFields.jsxでthree-colsクラスを使用
- form-group.thirdクラスを削除してシンプルなform-groupに統一
- より互換性の高いCSS実装に変更