### PR TITLE
Fix: モバイルで学習記録追加ウィンドウのはみ出しを修正

### DIFF
--- a/child-learning-app/src/components/TaskForm.css
+++ b/child-learning-app/src/components/TaskForm.css
@@ -326,7 +326,7 @@
 /* Mobile responsiveness */
 @media (max-width: 768px) {
   .task-form.sapix-form {
-    padding: 20px;
+    padding: 15px;
     border-radius: 12px;
   }
 
@@ -360,7 +360,7 @@
   }
 
   .custom-unit-form {
-    padding: 15px;
+    padding: 12px;
   }
 
   .custom-unit-form h3 {
@@ -368,17 +368,23 @@
   }
 
   .pastpaper-fields {
-    padding: 15px;
+    padding: 12px;
   }
 
   .related-units-checkboxes {
     grid-template-columns: 1fr;
+    padding: 10px;
+    gap: 8px;
+  }
+
+  .unit-checkbox-label {
+    padding: 6px 10px;
   }
 }
 
 @media (max-width: 480px) {
   .task-form.sapix-form {
-    padding: 15px;
+    padding: 12px;
   }
 
   .task-form h2 {
@@ -434,16 +440,18 @@
   }
 
   .pastpaper-fields {
-    padding: 12px;
+    padding: 10px;
   }
 
   .related-units-checkboxes {
     grid-template-columns: 1fr;
     max-height: 150px;
+    padding: 8px;
+    gap: 6px;
   }
 
   .unit-checkbox-label {
-    padding: 6px 10px;
+    padding: 5px 8px;
   }
 
   .unit-checkbox-label span {


### PR DESCRIPTION
- 768px以下: フォームパディング20px→15px、pastpaper-fieldsパディング15px→12px
- 768px以下: related-units-checkboxesのパディング15px→10px、ギャップ10px→8px
- 480px以下: フォームパディング15px→12px、pastpaper-fieldsパディング12px→10px
- 480px以下: related-units-checkboxesのパディング15px→8px、ギャップ10px→6px
- 単元チェックボックスラベルのパディングも縮小
- モバイルでウィンドウが画面幅に収まるよう全体的にコンパクト化