### PR TITLE
Fix: iPhoneで学習記録追加フォームが画面に収まるよう修正

### DIFF
--- a/child-learning-app/src/components/TaskForm.css
+++ b/child-learning-app/src/components/TaskForm.css
@@ -336,7 +336,11 @@
 
   .form-row {
     grid-template-columns: 1fr;
-    gap: 20px;
+    gap: 15px;
+  }
+
+  .form-row.three-cols {
+    grid-template-columns: 1fr;
   }
 
   .task-type-buttons {
@@ -357,6 +361,10 @@
     min-width: 44px;
     height: 44px;
     font-size: 1.1rem;
+  }
+
+  .unit-select-container {
+    gap: 8px;
   }
 
   .custom-unit-form {
@@ -401,6 +409,14 @@
     font-size: 0.9rem;
   }
 
+  .form-row {
+    gap: 12px;
+  }
+
+  .form-row.three-cols {
+    grid-template-columns: 1fr;
+  }
+
   .task-type-buttons {
     grid-template-columns: 1fr;
   }
@@ -419,6 +435,10 @@
     height: 40px;
     font-size: 1rem;
     padding: 8px 12px;
+  }
+
+  .unit-select-container {
+    gap: 6px;
   }
 
   .custom-unit-form {


### PR DESCRIPTION
- モバイル(768px以下)で.form-row.three-colsを明示的に1列グリッドに変更
- 480px以下でも.form-row.three-colsを1列に設定
- form-rowのギャップを768pxで15px、480pxで12pxに縮小
- unit-select-containerのギャップを768pxで8px、480pxで6pxに縮小
- CSSの詳細度の問題を解決（three-colsがモバイルで3列のまま残っていた）