### PR TITLE
Fix: 学習記録追加フォームを根本的にコンパクト化

### DIFF
--- a/child-learning-app/src/components/TaskForm.css
+++ b/child-learning-app/src/components/TaskForm.css
@@ -326,23 +326,23 @@
 /* Mobile responsiveness */
 @media (max-width: 768px) {
   .task-form.sapix-form {
-    padding: 12px;
+    padding: 10px;
     border-radius: 12px;
   }
 
   .task-form h2 {
-    font-size: 1.2rem;
-    margin-bottom: 15px;
+    font-size: 1.1rem;
+    margin-bottom: 10px;
   }
 
   .form-group {
-    margin-bottom: 15px;
+    margin-bottom: 10px;
   }
 
   .form-row {
     grid-template-columns: 1fr;
-    gap: 12px;
-    margin-bottom: 15px;
+    gap: 8px;
+    margin-bottom: 10px;
   }
 
   .form-row.three-cols {
@@ -351,85 +351,89 @@
 
   .task-type-buttons {
     grid-template-columns: repeat(2, 1fr);
-    gap: 8px;
+    gap: 6px;
   }
 
   .type-btn {
-    padding: 10px;
-    font-size: 0.85rem;
+    padding: 8px;
+    font-size: 0.8rem;
   }
 
   .priority-buttons {
     flex-direction: column;
-    gap: 8px;
+    gap: 6px;
   }
 
   .priority-btn {
-    padding: 10px;
-    font-size: 0.9rem;
+    padding: 8px;
+    font-size: 0.85rem;
   }
 
   .add-custom-unit-btn {
-    min-width: 42px;
-    height: 42px;
-    font-size: 1.05rem;
-  }
-
-  .unit-select-container {
-    gap: 8px;
-  }
-
-  .custom-unit-form {
-    padding: 12px;
-  }
-
-  .custom-unit-form h3 {
+    min-width: 40px;
+    height: 40px;
     font-size: 1rem;
   }
 
+  .unit-select-container {
+    gap: 6px;
+  }
+
+  .custom-unit-form {
+    padding: 10px;
+    margin-top: 10px;
+  }
+
+  .custom-unit-form h3 {
+    font-size: 0.95rem;
+    margin-bottom: 10px;
+  }
+
   .pastpaper-fields {
-    padding: 12px;
+    padding: 10px;
+    margin-top: 10px;
   }
 
   .related-units-checkboxes {
     grid-template-columns: 1fr;
-    padding: 10px;
-    gap: 8px;
+    padding: 8px;
+    gap: 6px;
   }
 
   .unit-checkbox-label {
-    padding: 6px 10px;
+    padding: 5px 8px;
   }
 }
 
 @media (max-width: 480px) {
   .task-form.sapix-form {
-    padding: 10px;
+    padding: 8px;
   }
 
   .task-form h2 {
-    font-size: 1.1rem;
-    margin-bottom: 12px;
+    font-size: 1rem;
+    margin-bottom: 8px;
   }
 
   .form-group {
-    margin-bottom: 12px;
+    margin-bottom: 8px;
   }
 
   .form-group label {
-    font-size: 0.85rem;
-    margin-bottom: 6px;
+    font-size: 0.8rem;
+    margin-bottom: 4px;
   }
 
   .form-group input,
   .form-group select {
-    padding: 8px 10px;
-    font-size: 0.85rem;
+    padding: 6px 8px;
+    font-size: 0.8rem;
+    border-radius: 6px;
   }
 
   .form-row {
-    gap: 10px;
-    margin-bottom: 12px;
+    gap: 6px;
+    margin-bottom: 8px;
   }
 
   .form-row.three-cols {
@@ -438,77 +442,83 @@
 
   .task-type-buttons {
     grid-template-columns: 1fr;
-    gap: 6px;
+    gap: 4px;
   }
 
   .type-btn {
-    padding: 8px;
-    font-size: 0.8rem;
+    padding: 6px;
+    font-size: 0.75rem;
   }
 
   .submit-btn.sapix-btn {
-    padding: 12px;
-    font-size: 0.95rem;
+    padding: 10px;
+    font-size: 0.9rem;
   }
 
   .add-custom-unit-btn {
-    min-width: 38px;
-    height: 38px;
-    font-size: 0.95rem;
-    padding: 6px 10px;
+    min-width: 36px;
+    height: 36px;
+    font-size: 0.9rem;
+    padding: 5px 8px;
   }
 
   .unit-select-container {
-    gap: 6px;
+    gap: 4px;
   }
 
   .custom-unit-form {
-    padding: 10px;
+    padding: 8px;
+    margin-top: 8px;
   }
 
   .custom-unit-form h3 {
-    font-size: 0.9rem;
-    margin-bottom: 10px;
+    font-size: 0.85rem;
+    margin-bottom: 8px;
   }
 
   .custom-unit-actions {
     flex-direction: column;
-    gap: 8px;
-    margin-top: 10px;
+    gap: 6px;
+    margin-top: 8px;
   }
 
   .btn-primary,
   .btn-secondary {
     width: 100%;
-    padding: 10px;
-    font-size: 0.9rem;
+    padding: 8px;
+    font-size: 0.85rem;
   }
 
   .pastpaper-fields {
-    padding: 8px;
+    padding: 6px;
+    margin-top: 8px;
   }
 
   .related-units-checkboxes {
     grid-template-columns: 1fr;
-    max-height: 150px;
-    padding: 6px;
-    gap: 4px;
+    max-height: 120px;
+    padding: 4px;
+    gap: 3px;
   }
 
   .unit-checkbox-label {
-    padding: 4px 6px;
+    padding: 3px 5px;
   }
 
   .unit-checkbox-label span {
-    font-size: 0.8rem;
+    font-size: 0.75rem;
   }
 
   .priority-buttons {
-    gap: 6px;
+    gap: 4px;
   }
 
   .priority-btn {
-    padding: 8px;
-    font-size: 0.85rem;
+    padding: 6px;
+    font-size: 0.8rem;
+  }
+
+  .form-actions {
+    margin-top: 8px;
   }
 }


### PR DESCRIPTION
【抜本的な改善 - すべてのスペーシングを大幅削減】

480px以下（iPhone等）:
- フォームパディング: 10px→8px
- h2: 1.1rem→1rem, margin: 12px→8px
- ラベル: 0.85rem→0.8rem, margin: 6px→4px
- 入力: padding 8px 10px→6px 8px, font 0.85rem→0.8rem
- form-group: margin 12px→8px
- form-row: gap 10px→6px, margin 12px→8px
- タスク種別: padding 8px→6px, font 0.8rem→0.75rem, gap 6px→4px
- 送信ボタン: padding 12px→10px, font 0.95rem→0.9rem
- +ボタン: 38px→36px
- 過去問フィールド: padding 8px→6px
- 関連単元: height 150px→120px, padding 6px→4px, gap 4px→3px
- 単元ラベル: padding 4px 6px→3px 5px, font 0.8rem→0.75rem
- 優先度: padding 8px→6px, font 0.85rem→0.8rem, gap 6px→4px

768px以下（タブレット）:
- フォームパディング: 12px→10px
- h2: 1.2rem→1.1rem, margin: 15px→10px
- form-group: margin 15px→10px
- form-row: gap 12px→8px, margin 15px→10px
- タスク種別: padding 10px→8px, font 0.85rem→0.8rem, gap 8px→6px
- 優先度: padding 10px→8px, font 0.9rem→0.85rem, gap 8px→6px
- +ボタン: 42px→40px
- 過去問フィールド: padding 12px→10px
- 関連単元: padding 10px→8px, gap 8px→6px
- 単元ラベル: padding 6px 10px→5px 8px