### PR TITLE
Fix: 学習記録追加フォームを極限までコンパクト化（全体的に縮小）

### DIFF
--- a/child-learning-app/src/components/TaskForm.css
+++ b/child-learning-app/src/components/TaskForm.css
@@ -407,34 +407,36 @@
 
 @media (max-width: 480px) {
   .task-form.sapix-form {
-    padding: 6px;
-    margin-bottom: 12px;
+    padding: 4px;
+    margin-bottom: 8px;
+    border-radius: 8px;
   }
 
   .task-form h2 {
-    font-size: 0.95rem;
-    margin-bottom: 6px;
+    font-size: 0.85rem;
+    margin-bottom: 4px;
   }
 
   .form-group {
-    margin-bottom: 6px;
+    margin-bottom: 4px;
   }
 
   .form-group label {
-    font-size: 0.75rem;
-    margin-bottom: 3px;
+    font-size: 0.7rem;
+    margin-bottom: 2px;
   }
 
   .form-group input,
   .form-group select {
-    padding: 5px 6px;
-    font-size: 0.75rem;
+    padding: 4px 5px;
+    font-size: 0.7rem;
     border-radius: 4px;
+    border-width: 1px;
   }
 
   .form-row {
-    gap: 4px;
-    margin-bottom: 6px;
+    gap: 3px;
+    margin-bottom: 4px;
   }
 
   .form-row.three-cols {
@@ -443,84 +445,94 @@
 
   .task-type-buttons {
     grid-template-columns: 1fr;
-    gap: 3px;
+    gap: 2px;
   }
 
   .type-btn {
-    padding: 5px;
-    font-size: 0.7rem;
+    padding: 4px;
+    font-size: 0.65rem;
   }
 
   .submit-btn.sapix-btn {
-    padding: 8px;
-    font-size: 0.85rem;
+    padding: 6px;
+    font-size: 0.8rem;
   }
 
   .add-custom-unit-btn {
-    min-width: 32px;
-    height: 32px;
-    font-size: 0.85rem;
-    padding: 4px 6px;
+    min-width: 28px;
+    height: 28px;
+    font-size: 0.8rem;
+    padding: 3px 5px;
   }
 
   .unit-select-container {
-    gap: 3px;
+    gap: 2px;
   }
 
   .custom-unit-form {
-    padding: 6px;
-    margin-top: 6px;
+    padding: 4px;
+    margin-top: 4px;
   }
 
   .custom-unit-form h3 {
-    font-size: 0.8rem;
-    margin-bottom: 6px;
+    font-size: 0.75rem;
+    margin-bottom: 4px;
   }
 
   .custom-unit-actions {
     flex-direction: column;
-    gap: 4px;
-    margin-top: 6px;
+    gap: 3px;
+    margin-top: 4px;
   }
 
   .btn-primary,
   .btn-secondary {
     width: 100%;
-    padding: 6px;
-    font-size: 0.8rem;
-  }
-
-  .pastpaper-fields {
-    padding: 4px;
-    margin-top: 6px;
-  }
-
-  .related-units-checkboxes {
-    grid-template-columns: 1fr;
-    max-height: 100px;
-    padding: 3px;
-    gap: 2px;
-  }
-
-  .unit-checkbox-label {
-    padding: 2px 4px;
-  }
-
-  .unit-checkbox-label span {
-    font-size: 0.7rem;
-  }
-
-  .priority-buttons {
-    gap: 3px;
-  }
-
-  .priority-btn {
     padding: 5px;
     font-size: 0.75rem;
   }
 
+  .pastpaper-fields {
+    padding: 3px;
+    margin-top: 4px;
+  }
+
+  .related-units-checkboxes {
+    grid-template-columns: 1fr;
+    max-height: 80px;
+    padding: 2px;
+    gap: 1px;
+  }
+
+  .unit-checkbox-label {
+    padding: 1px 3px;
+  }
+
+  .unit-checkbox-label span {
+    font-size: 0.65rem;
+  }
+
+  .unit-checkbox-label input[type="checkbox"] {
+    width: 14px;
+    height: 14px;
+  }
+
+  .priority-buttons {
+    gap: 2px;
+  }
+
+  .priority-btn {
+    padding: 4px;
+    font-size: 0.7rem;
+  }
+
   .form-actions {
-    margin-top: 6px;
-    gap: 4px;
+    margin-top: 4px;
+    gap: 3px;
+  }
+
+  .cancel-btn {
+    padding: 6px;
+    font-size: 0.8rem;
   }
 }


### PR DESCRIPTION
【480px以下での極限までの縮小】
- フォームパディング: 6px→4px
- タイトル: 0.95rem→0.85rem, margin: 6px→4px
- form-groupマージン: 6px→4px
- ラベル: 0.75rem→0.7rem, margin: 3px→2px
- 入力フィールド: padding 5px 6px→4px 5px, font: 0.75rem→0.7rem, border: 2px→1px
- form-rowギャップ: 4px→3px, margin: 6px→4px
- タスク種別: padding 5px→4px, font: 0.7rem→0.65rem, gap: 3px→2px
- 送信ボタン: padding 8px→6px, font: 0.85rem→0.8rem
- +ボタン: 32px→28px
- 過去問フィールド: padding 4px→3px
- 関連単元: height 100px→80px, padding 3px→2px, gap 2px→1px
- 関連単元ラベル: padding 2px 4px→1px 3px, font: 0.7rem→0.65rem
- チェックボックス: 18px→14px
- 優先度: padding 5px→4px, font: 0.75rem→0.7rem, gap: 3px→2px
- アクションボタン: padding 6px→5px, font: 0.8rem→0.75rem

すべての要素を最小限のサイズまで縮小し、iPhone SE (375px)等の小画面でも快適に表示