### PR TITLE
Fix: TaskForm 768px media query now matches past paper card sizing

### DIFF
--- a/child-learning-app/src/components/TaskForm.css
+++ b/child-learning-app/src/components/TaskForm.css
@@ -326,23 +326,23 @@
 /* Mobile responsiveness */
 @media (max-width: 768px) {
   .task-form.sapix-form {
-    padding: 10px;
+    padding: 6px;
     border-radius: 12px;
   }
 
   .task-form h2 {
-    font-size: 1.1rem;
-    margin-bottom: 10px;
+    font-size: 0.9rem;
+    margin-bottom: 6px;
   }
 
   .form-group {
-    margin-bottom: 10px;
+    margin-bottom: 6px;
   }
 
   .form-row {
     grid-template-columns: 1fr;
-    gap: 8px;
-    margin-bottom: 10px;
+    gap: 4px;
+    margin-bottom: 6px;
   }
 
   .form-row.three-cols {
@@ -351,57 +351,57 @@
 
   .task-type-buttons {
     grid-template-columns: repeat(2, 1fr);
-    gap: 6px;
+    gap: 4px;
   }
 
   .type-btn {
-    padding: 8px;
-    font-size: 0.8rem;
+    padding: 6px;
+    font-size: 0.75rem;
   }
 
   .priority-buttons {
     flex-direction: column;
-    gap: 6px;
+    gap: 4px;
   }
 
   .priority-btn {
-    padding: 8px;
-    font-size: 0.85rem;
+    padding: 6px;
+    font-size: 0.75rem;
   }
 
   .add-custom-unit-btn {
-    min-width: 40px;
-    height: 40px;
-    font-size: 1rem;
+    min-width: 32px;
+    height: 32px;
+    font-size: 0.85rem;
   }
 
   .unit-select-container {
-    gap: 6px;
+    gap: 4px;
   }
 
   .custom-unit-form {
-    padding: 10px;
-    margin-top: 10px;
+    padding: 6px;
+    margin-top: 6px;
   }
 
   .custom-unit-form h3 {
-    font-size: 0.95rem;
-    margin-bottom: 10px;
+    font-size: 0.85rem;
+    margin-bottom: 6px;
   }
 
   .pastpaper-fields {
-    padding: 10px;
-    margin-top: 10px;
+    padding: 6px;
+    margin-top: 6px;
   }
 
   .related-units-checkboxes {
     grid-template-columns: 1fr;
-    padding: 8px;
-    gap: 6px;
+    padding: 6px;
+    gap: 4px;
   }
 
   .unit-checkbox-label {
-    padding: 5px 8px;
+    padding: 4px 6px;
   }
 }
 


### PR DESCRIPTION
Problem: At 768px breakpoint (iPhone landscape, iPad portrait), TaskForm had 10px padding while past paper cards had 6px padding, making TaskForm appear 67% larger.

Solution: Reduced all 768px media query values:
- padding: 10px → 6px
- gaps: 6-8px → 4px
- margins: 10px → 6px
- font-sizes: 0.8-1.1rem → 0.75-0.9rem

Now TaskForm matches past paper card sizing across all breakpoints.