### PR TITLE
Fix: TaskForm base styles (768px+) now match past paper card sizing

### DIFF
--- a/child-learning-app/src/components/TaskForm.css
+++ b/child-learning-app/src/components/TaskForm.css
@@ -1,9 +1,9 @@
 .task-form.sapix-form {
   background: white;
-  border-radius: 15px;
-  padding: 25px;
-  box-shadow: 0 8px 24px rgba(30, 64, 175, 0.15);
-  margin-bottom: 20px;
+  border-radius: 12px;
+  padding: 12px;
+  box-shadow: 0 4px 12px rgba(30, 64, 175, 0.15);
+  margin-bottom: 12px;
   border: 1px solid rgba(30, 64, 175, 0.1);
   min-width: 0;
   overflow-x: hidden;
@@ -11,16 +11,16 @@
 
 .task-form h2 {
   color: #1e40af;
-  margin-bottom: 20px;
-  font-size: 1.5rem;
+  margin-bottom: 12px;
+  font-size: 1.1rem;
   font-weight: 700;
 }
 
 .form-row {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 15px;
-  margin-bottom: 20px;
+  gap: 8px;
+  margin-bottom: 10px;
 }
 
 .form-row.three-cols {
@@ -33,25 +33,25 @@
 }
 
 .form-group {
-  margin-bottom: 20px;
+  margin-bottom: 10px;
   min-width: 0;
 }
 
 .form-group label {
   display: block;
-  margin-bottom: 8px;
+  margin-bottom: 4px;
   color: #1e293b;
   font-weight: 600;
-  font-size: 0.95rem;
+  font-size: 0.85rem;
 }
 
 .form-group input,
 .form-group select {
   width: 100%;
-  padding: 12px 15px;
+  padding: 8px 10px;
   border: 2px solid #e2e8f0;
-  border-radius: 8px;
-  font-size: 1rem;
+  border-radius: 6px;
+  font-size: 0.9rem;
   box-sizing: border-box;
   transition: all 0.3s ease;
   background: white;
@@ -66,17 +66,17 @@
 
 .task-type-buttons {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  gap: 6px;
 }
 
 .type-btn {
-  padding: 12px;
+  padding: 8px;
   border: 2px solid #e2e8f0;
   background: white;
-  border-radius: 8px;
+  border-radius: 6px;
   cursor: pointer;
-  font-size: 0.9rem;
+  font-size: 0.8rem;
   font-weight: 500;
   transition: all 0.3s ease;
   color: #475569;
@@ -97,17 +97,17 @@
 
 .priority-buttons {
   display: flex;
-  gap: 10px;
+  gap: 6px;
 }
 
 .priority-btn {
   flex: 1;
-  padding: 10px;
+  padding: 6px;
   border: 2px solid #e2e8f0;
   background: white;
-  border-radius: 8px;
+  border-radius: 6px;
   cursor: pointer;
-  font-size: 0.9rem;
+  font-size: 0.8rem;
   font-weight: 600;
   transition: all 0.3s ease;
 }
@@ -119,12 +119,12 @@
 
 .submit-btn.sapix-btn {
   width: 100%;
-  padding: 16px;
+  padding: 10px;
   background: linear-gradient(135deg, #1e40af 0%, #3b82f6 100%);
   color: white;
   border: none;
-  border-radius: 10px;
-  font-size: 1.1rem;
+  border-radius: 8px;
+  font-size: 0.95rem;
   font-weight: 700;
   cursor: pointer;
   transition: all 0.3s ease;
@@ -138,7 +138,7 @@
 
 .form-actions {
   display: flex;
-  gap: 12px;
+  gap: 8px;
 }
 
 .form-actions .submit-btn {
@@ -146,12 +146,12 @@
 }
 
 .cancel-btn {
-  padding: 16px 24px;
+  padding: 10px 16px;
   background: #94a3b8;
   color: white;
   border: none;
-  border-radius: 10px;
-  font-size: 1rem;
+  border-radius: 8px;
+  font-size: 0.9rem;
   font-weight: 700;
   cursor: pointer;
   transition: all 0.3s ease;
@@ -165,7 +165,7 @@
 /* Custom unit form styles */
 .unit-select-container {
   display: flex;
-  gap: 10px;
+  gap: 6px;
   align-items: center;
   min-width: 0;
 }
@@ -176,19 +176,19 @@
 }
 
 .add-custom-unit-btn {
-  padding: 12px 16px;
+  padding: 8px 10px;
   background: linear-gradient(135deg, #10b981 0%, #34d399 100%);
   color: white;
   border: none;
-  border-radius: 8px;
-  font-size: 1.2rem;
+  border-radius: 6px;
+  font-size: 1rem;
   font-weight: 700;
   cursor: pointer;
   transition: all 0.3s ease;
   box-shadow: 0 2px 8px rgba(16, 185, 129, 0.3);
   flex-shrink: 0;
-  min-width: 48px;
-  height: 48px;
+  min-width: 36px;
+  height: 36px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -203,9 +203,9 @@
 .custom-unit-form {
   background: #f0f9ff;
   border: 2px solid #bae6fd;
-  border-radius: 12px;
-  padding: 20px;
-  margin-top: 15px;
+  border-radius: 8px;
+  padding: 10px;
+  margin-top: 8px;
   animation: slideDown 0.3s ease;
   min-width: 0;
   overflow: hidden;
@@ -224,25 +224,25 @@
 
 .custom-unit-form h3 {
   color: #0c4a6e;
-  font-size: 1.1rem;
-  margin-bottom: 15px;
+  font-size: 0.95rem;
+  margin-bottom: 8px;
   font-weight: 700;
 }
 
 .custom-unit-actions {
   display: flex;
-  gap: 10px;
-  margin-top: 15px;
+  gap: 6px;
+  margin-top: 8px;
 }
 
 .btn-primary {
   flex: 1;
-  padding: 12px 20px;
+  padding: 8px 12px;
   background: linear-gradient(135deg, #1e40af 0%, #3b82f6 100%);
   color: white;
   border: none;
-  border-radius: 8px;
-  font-size: 1rem;
+  border-radius: 6px;
+  font-size: 0.85rem;
   font-weight: 700;
   cursor: pointer;
   transition: all 0.3s ease;
@@ -257,12 +257,12 @@
 
 .btn-secondary {
   flex: 1;
-  padding: 12px 20px;
+  padding: 8px 12px;
   background: white;
   color: #64748b;
   border: 2px solid #e2e8f0;
-  border-radius: 8px;
-  font-size: 1rem;
+  border-radius: 6px;
+  font-size: 0.85rem;
   font-weight: 700;
   cursor: pointer;
   transition: all 0.3s ease;
@@ -278,9 +278,9 @@
 .pastpaper-fields {
   background: #fef3c7;
   border: 2px solid #fbbf24;
-  border-radius: 12px;
-  padding: 20px;
-  margin-top: 15px;
+  border-radius: 8px;
+  padding: 10px;
+  margin-top: 8px;
   animation: slideDown 0.3s ease;
   min-width: 0;
   overflow: hidden;
@@ -288,23 +288,23 @@
 
 .related-units-checkboxes {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 10px;
-  max-height: 200px;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: 6px;
+  max-height: 150px;
   overflow-y: auto;
-  padding: 15px;
+  padding: 8px;
   background: white;
-  border-radius: 8px;
+  border-radius: 6px;
   border: 2px solid #e2e8f0;
 }
 
 .unit-checkbox-label {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   cursor: pointer;
-  padding: 8px 12px;
-  border-radius: 6px;
+  padding: 6px 8px;
+  border-radius: 4px;
   transition: all 0.2s ease;
 }
 


### PR DESCRIPTION
Root cause found: At 768px+ (iPad Pro, large phones in landscape), TaskForm had padding 25px while past paper cards had 12px (208% larger!)

Solution: Reduced ALL base styles to match or be smaller than past paper cards:
- Form padding: 25px → 12px
- Title: 1.5rem → 1.1rem
- Margins: 15-20px → 8-12px
- Gaps: 10-15px → 6-8px
- Input padding: 12px 15px → 8px 10px
- Font sizes: 0.9-1.2rem → 0.8-0.95rem
- Button padding: 12-16px → 8-10px
- Border radius: 8-15px → 6-12px

Now TaskForm matches past paper cards across ALL screen sizes:
- 768px+: padding 12px (both)
- 481-768px: padding 6px (both)
- ≤480px: TaskForm 4px, PastPaper 6px (mobile extreme compact)