### PR TITLE
Feature: 過去問の学習記録を折りたたみ可能に変更

### DIFF
--- a/child-learning-app/src/components/PastPaperView.css
+++ b/child-learning-app/src/components/PastPaperView.css
@@ -551,6 +551,28 @@
   font-size: 0.7rem;
 }
 
+/* 学習記録展開/折りたたみボタン */
+.toggle-sessions-btn {
+  width: 100%;
+  padding: 6px 8px;
+  background: #f0f9ff;
+  border: 1px solid #bae6fd;
+  border-radius: 6px;
+  color: #0369a1;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  margin-bottom: 3px;
+  text-align: left;
+}
+
+.toggle-sessions-btn:hover {
+  background: #e0f2fe;
+  border-color: #7dd3fc;
+  transform: translateY(-1px);
+}
+
 .session-label {
   font-weight: 600;
   color: #64748b;

--- a/child-learning-app/src/components/PastPaperView.jsx
+++ b/child-learning-app/src/components/PastPaperView.jsx
@@ -42,6 +42,7 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
     unitId: '',  // 単一の単元ID
     fileUrl: ''  // GoogleドライブやPDFのURL
   })
+  const [expandedSessions, setExpandedSessions] = useState({}) // 学習記録の展開状態 (taskId -> boolean)
 
   // 過去問タスクのみフィルタリング（学年無関係）
   const pastPaperTasks = useMemo(() => {
@@ -351,6 +352,14 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
       ...editForm,
       unitId: unitId
     })
+  }
+
+  // 学習記録の展開/折りたたみをトグル
+  const toggleSessionExpanded = (taskId) => {
+    setExpandedSessions(prev => ({
+      ...prev,
+      [taskId]: !prev[taskId]
+    }))
   }
 
   const groupedData = viewMode === 'school' ? groupBySchool() : groupByUnit()
@@ -793,8 +802,18 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
                         </div>
                       )}
 
-                      {/* セッション一覧（編集モードでない場合のみ表示） */}
+                      {/* 学習記録の展開/折りたたみボタン（編集モードでなく、セッションがある場合のみ表示） */}
                       {editingTaskId !== task.id && taskSessions.length > 0 && (
+                        <button
+                          className="toggle-sessions-btn"
+                          onClick={() => toggleSessionExpanded(task.id)}
+                        >
+                          {expandedSessions[task.id] ? '▼' : '▶'} 学習記録 ({taskSessions.length}回)
+                        </button>
+                      )}
+
+                      {/* セッション一覧（編集モードでなく、展開されている場合のみ表示） */}
+                      {editingTaskId !== task.id && expandedSessions[task.id] && taskSessions.length > 0 && (
                         <div className="sessions-list">
                           {taskSessions.map(session => (
                             <div key={session.firestoreId} className="session-item">


### PR DESCRIPTION
変更内容:
1. 学習記録の展開/折りたたみ状態を管理 (expandedSessions)
2. トグルボタンを追加「▶ 学習記録 (N回)」
3. クリックで学習記録の表示/非表示を切り替え
4. ボタンスタイル: 青色の背景、ホバー時のアニメーション

これにより、複数の過去問カードがある場合でも
画面がスッキリし、必要な情報だけを表示できます