### PR TITLE
Fix: iPhone表示での科目ボタンを横書きに統一

### DIFF
--- a/child-learning-app/src/components/PastPaperView.css
+++ b/child-learning-app/src/components/PastPaperView.css
@@ -953,7 +953,19 @@
   .subject-buttons,
   .subject-selector-inline {
     grid-template-columns: repeat(4, 1fr);
-    gap: 10px;
+    gap: 8px;
+  }
+
+  .subject-btn {
+    padding: 10px 6px;
+    font-size: 0.8rem;
+    gap: 4px;
+    flex-direction: row;
+    white-space: nowrap;
+  }
+
+  .subject-emoji {
+    font-size: 1rem;
   }
 
   .view-header h2 {


### PR DESCRIPTION
iPhoneなど480px以下の狭い画面で、科目ボタンの絵文字とテキストが
縦に並んでしまう問題を修正しました。

変更内容:
- 480px以下で絵文字のサイズを縮小（1.25rem → 1rem）
- ボタンのpaddingを調整（12px → 10px 6px）
- テキストサイズを縮小（0.9rem → 0.8rem）
- 絵文字とテキストの間隔を縮小（10px → 4px）
- flex-direction: rowを明示的に設定
- white-space: nowrapで折り返しを防止
- グリッドのgapを縮小（10px → 8px）