### PR TITLE
Fix: 過去問フィルタボタンをダッシュボードのスタイルに統一

### DIFF
--- a/child-learning-app/src/components/PastPaperView.css
+++ b/child-learning-app/src/components/PastPaperView.css
@@ -322,29 +322,31 @@
 
 .mode-btn,
 .filter-btn {
-  padding: 10px 20px;
-  border: 2px solid #e2e8f0;
+  padding: 10px 18px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
   background: white;
-  border-radius: 8px;
+  border-radius: 10px;
   cursor: pointer;
-  font-size: 0.95rem;
+  font-size: 0.9375rem;
   font-weight: 600;
-  transition: all 0.3s ease;
-  color: #475569;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  color: #86868b;
+  letter-spacing: -0.01em;
 }
 
 .mode-btn:hover,
 .filter-btn:hover {
-  border-color: #cbd5e1;
-  transform: translateY(-2px);
+  border-color: #007AFF;
+  background: rgba(0, 122, 255, 0.08);
+  transform: scale(1.02);
 }
 
 .mode-btn.active,
 .filter-btn.active {
-  background: #3b82f6;
+  border-color: #007AFF;
+  background: #007AFF;
   color: white;
-  border-color: #3b82f6;
-  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
+  box-shadow: 0 2px 8px rgba(0, 122, 255, 0.25);
 }
 
 /* コンテンツ */
@@ -983,8 +985,8 @@
 
   .mode-btn,
   .filter-btn {
-    padding: 8px 16px;
-    font-size: 0.9rem;
+    padding: 6px 12px;
+    font-size: 0.85rem;
   }
 
   .session-form {


### PR DESCRIPTION
iPhoneでの表示において、過去問の表示モード（学校別/単元別）ボタンが
ダッシュボードの学年ボタンよりも大きなスペースを消費していた問題を修正。

変更内容:
- paddingを統一: 10px 20px → 10px 18px
- borderを統一: 2px → 1px（細く）
- border-radiusを統一: 8px → 10px
- font-sizeを統一: 0.95rem → 0.9375rem
- transitionを統一: ease → cubic-bezier
- colorを統一: #475569 → #86868b
- hoverスタイルをダッシュボードと同じに変更

480px以下のモバイル対応:
- paddingを統一: 8px 16px → 6px 12px
- font-sizeを統一: 0.9rem → 0.85rem