### PR TITLE
Fix: フィルタのラベルとボタンを横並びに変更

### DIFF
--- a/child-learning-app/src/components/PastPaperView.css
+++ b/child-learning-app/src/components/PastPaperView.css
@@ -293,7 +293,11 @@
 }
 
 .filter-group {
+  display: flex;
+  align-items: center;
+  gap: 12px;
   margin-bottom: 20px;
+  flex-wrap: wrap;
 }
 
 .filter-group:last-child {
@@ -301,10 +305,8 @@
 }
 
 .filter-group label {
-  display: block;
   font-weight: 600;
   color: #1d1d1f;
-  margin-bottom: 12px;
   font-size: 0.9375rem;
   letter-spacing: -0.01em;
 }
@@ -963,8 +965,8 @@
     padding: 4px;
   }
 
-  .filter-group label {
-    margin-bottom: 8px;
+  .filter-group {
+    gap: 8px;
   }
 
   .subject-buttons,


### PR DESCRIPTION
ダッシュボードと同じように、フィルタのラベル（「表示モード:」「科目:」）と
ボタンを同じ行に横並びで表示するように変更しました。

変更内容:
- .filter-group に display: flex, align-items: center を追加
- gap: 12px でラベルとボタンの間隔を設定
- flex-wrap: wrap でモバイル対応
- label の display: block と margin-bottom を削除
- 480px以下で gap: 8px に縮小