### PR TITLE
Fix: フィルタエリアの縦方向スペースを大幅削減

### DIFF
--- a/child-learning-app/src/components/PastPaperView.css
+++ b/child-learning-app/src/components/PastPaperView.css
@@ -285,23 +285,16 @@
 }
 
 .filter-row {
-  margin-bottom: 20px;
-}
-
-.filter-row:last-child {
-  margin-bottom: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .filter-group {
   display: flex;
   align-items: center;
   gap: 12px;
-  margin-bottom: 20px;
   flex-wrap: wrap;
-}
-
-.filter-group:last-child {
-  margin-bottom: 0;
 }
 
 .filter-group label {
@@ -965,8 +958,12 @@
     padding: 4px;
   }
 
-  .filter-group {
+  .filter-row {
     gap: 8px;
+  }
+
+  .filter-group {
+    gap: 6px;
   }
 
   .subject-buttons,


### PR DESCRIPTION
フィルタエリアの縦方向のスペースをダッシュボードと同等まで削減しました。

変更内容:
- .filter-rowと.filter-groupのmargin-bottomを削除
- .filter-rowにgap: 12pxを追加（表示モードと科目の間隔を20px→12pxに削減）
- .filter-rowをflexコンテナに変更（flex-direction: column）
- より効率的なスペース管理

モバイル対応:
- 480px以下で.filter-row gap: 8px
- 480px以下で.filter-group gap: 6px（ラベルとボタンの間隔を縮小）