### PR TITLE
Fix: 科目ラベルを削除してダッシュボードと完全統一

### DIFF
--- a/child-learning-app/src/components/PastPaperView.jsx
+++ b/child-learning-app/src/components/PastPaperView.jsx
@@ -559,24 +559,21 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
             </div>
           </div>
 
-          <div className="filter-group">
-            <label>科目:</label>
-            <div className="subject-buttons">
-              {subjects.map((subject) => (
-                <button
-                  key={subject}
-                  className={`subject-btn ${selectedSubject === subject ? 'active' : ''}`}
-                  onClick={() => setSelectedSubject(subject)}
-                  style={{
-                    borderColor: selectedSubject === subject ? subjectColors[subject] : '#e2e8f0',
-                    background: selectedSubject === subject ? `${subjectColors[subject]}15` : 'white',
-                  }}
-                >
-                  <span className="subject-emoji">{subjectEmojis[subject]}</span>
-                  <span>{subject}</span>
-                </button>
-              ))}
-            </div>
+          <div className="subject-buttons">
+            {subjects.map((subject) => (
+              <button
+                key={subject}
+                className={`subject-btn ${selectedSubject === subject ? 'active' : ''}`}
+                onClick={() => setSelectedSubject(subject)}
+                style={{
+                  borderColor: selectedSubject === subject ? subjectColors[subject] : '#e2e8f0',
+                  background: selectedSubject === subject ? `${subjectColors[subject]}15` : 'white',
+                }}
+              >
+                <span className="subject-emoji">{subjectEmojis[subject]}</span>
+                <span>{subject}</span>
+              </button>
+            ))}
           </div>
         </div>
       </div>


### PR DESCRIPTION
ダッシュボードと同じように、科目フィルタから「科目:」ラベルを削除しました。
これにより、科目ボタンだけが表示され、よりコンパクトでクリーンなUIになります。

変更内容:
- 「科目:」ラベルとその親要素(.filter-group)を削除
- .subject-buttonsを直接配置
- ダッシュボードの科目セレクターと完全に同じ表示