### PR TITLE
Fix: 表示モードと科目の間隔をダッシュボードと完全統一

### DIFF
--- a/child-learning-app/src/components/PastPaperView.css
+++ b/child-learning-app/src/components/PastPaperView.css
@@ -287,7 +287,7 @@
 .filter-row {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 20px;
 }
 
 .filter-group {
@@ -959,11 +959,11 @@
   }
 
   .filter-row {
-    gap: 8px;
+    gap: 20px;
   }
 
   .filter-group {
-    gap: 6px;
+    gap: 8px;
   }
 
   .subject-buttons,


### PR DESCRIPTION
ダッシュボードでは学年と科目の間が20pxですが、
過去問では12pxになっていたため、20pxに修正しました。

変更内容:
- .filter-row gap: 12px → 20px（表示モードと科目の間隔）
- 480px以下でも gap: 20px を維持（ダッシュボードと同じ）
- これによりダッシュボードと完全に同じスペーシングになります