### PR TITLE
Fix: フィルタ構造を完全統一＆センター配置に修正

### DIFF
--- a/child-learning-app/src/components/PastPaperView.css
+++ b/child-learning-app/src/components/PastPaperView.css
@@ -293,6 +293,7 @@
 .filter-group {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 12px;
   flex-wrap: wrap;
 }
@@ -302,13 +303,6 @@
   color: #1d1d1f;
   font-size: 0.9375rem;
   letter-spacing: -0.01em;
-}
-
-.mode-buttons,
-.grade-buttons {
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
 }
 
 .subject-buttons {
@@ -990,11 +984,6 @@
 
   .group-title {
     font-size: 1.2rem;
-  }
-
-  .mode-buttons,
-  .grade-buttons {
-    gap: 8px;
   }
 
   .mode-btn,

--- a/child-learning-app/src/components/PastPaperView.jsx
+++ b/child-learning-app/src/components/PastPaperView.jsx
@@ -543,20 +543,18 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
         <div className="filter-row">
           <div className="filter-group">
             <label>表示モード:</label>
-            <div className="mode-buttons">
-              <button
-                className={`mode-btn ${viewMode === 'school' ? 'active' : ''}`}
-                onClick={() => setViewMode('school')}
-              >
-                🏫 学校別
-              </button>
-              <button
-                className={`mode-btn ${viewMode === 'unit' ? 'active' : ''}`}
-                onClick={() => setViewMode('unit')}
-              >
-                📚 単元別
-              </button>
-            </div>
+            <button
+              className={`mode-btn ${viewMode === 'school' ? 'active' : ''}`}
+              onClick={() => setViewMode('school')}
+            >
+              🏫 学校別
+            </button>
+            <button
+              className={`mode-btn ${viewMode === 'unit' ? 'active' : ''}`}
+              onClick={() => setViewMode('unit')}
+            >
+              📚 単元別
+            </button>
           </div>
 
           <div className="subject-buttons">

--- a/child-learning-app/src/components/UnitDashboard.css
+++ b/child-learning-app/src/components/UnitDashboard.css
@@ -15,6 +15,7 @@
 .grade-selector {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 12px;
   margin-bottom: 20px;
   flex-wrap: wrap;


### PR DESCRIPTION
ダッシュボードと過去問のフィルタ構造を完全に統一し、
センター配置に修正しました。

【ダッシュボード】
- .grade-selectorにjustify-content: centerを追加
- 学年フィルタがセンター配置になりました

【過去問】
- .mode-buttonsコンテナを削除（余分な親要素）
- ボタンを直接.filter-groupの子要素に配置
- .filter-groupにjustify-content: centerを追加
- センター配置に統一

【CSS整理】
- 使われていない.mode-buttons, .grade-buttonsスタイルを削除

これによりダッシュボードと過去問が完全に同じ構造・レイアウトになります。