### PR TITLE
Fix: 480pxでの科目ボタンスタイルをダッシュボードと完全統一

### DIFF
--- a/child-learning-app/src/components/PastPaperView.css
+++ b/child-learning-app/src/components/PastPaperView.css
@@ -962,22 +962,14 @@
     font-size: 0.85rem;
   }
 
-  .subject-buttons,
   .subject-selector-inline {
     grid-template-columns: repeat(4, 1fr);
     gap: 10px;
   }
 
-  .subject-btn {
-    padding: 10px 6px;
-    font-size: 0.8rem;
-    gap: 4px;
-    flex-direction: row;
-    white-space: nowrap;
-  }
-
-  .subject-emoji {
-    font-size: 1rem;
+  .subject-buttons {
+    grid-template-columns: repeat(4, 1fr);
+    gap: 10px;
   }
 
   .view-header h2 {


### PR DESCRIPTION
- 480pxメディアクエリから.subject-btnの上書きを削除
- 480pxメディアクエリから.subject-emojiの上書きを削除
- ダッシュボードと同様に基本スタイル(padding: 16px, font-size: 0.9375rem)を維持
- .subject-buttonsのgridスタイルのみ定義(dashboard完全一致)