### PR TITLE
Fix: 親要素のパディングをダッシュボードと完全統一

### DIFF
--- a/child-learning-app/src/components/PastPaperView.css
+++ b/child-learning-app/src/components/PastPaperView.css
@@ -1,7 +1,5 @@
 .pastpaper-view {
-  max-width: 1400px;
-  margin: 0 auto;
-  padding: 20px;
+  padding: 24px 0;
 }
 
 .view-header {
@@ -839,10 +837,6 @@
   .subject-btn {
     padding: 12px;
     font-size: 0.9rem;
-  }
-
-  .pastpaper-view {
-    padding: 15px;
   }
 
   .header-title-row {


### PR DESCRIPTION
- .pastpaper-viewをpadding: 24px 0に変更（Dashboard統一）
- max-width: 1400pxとmargin: 0 autoを削除
- 768pxでのpadding: 15pxを削除
- これにより科目ボタンの幅が十分確保され、縦書き問題を解決
- フィルタエリアの表示がダッシュボードと完全一致