### PR TITLE
Fix: 480pxで科目ボタンを横書きに確実に修正（両ファイル統一）

### DIFF
--- a/child-learning-app/src/components/PastPaperView.css
+++ b/child-learning-app/src/components/PastPaperView.css
@@ -966,6 +966,18 @@
     gap: 10px;
   }
 
+  .subject-btn {
+    padding: 10px 6px;
+    font-size: 0.8rem;
+    gap: 4px;
+    flex-direction: row;
+    white-space: nowrap;
+  }
+
+  .subject-emoji {
+    font-size: 1rem;
+  }
+
   .view-header h2 {
     font-size: 1.3rem;
   }

--- a/child-learning-app/src/components/UnitDashboard.css
+++ b/child-learning-app/src/components/UnitDashboard.css
@@ -696,6 +696,18 @@
     gap: 10px;
   }
 
+  .subject-btn {
+    padding: 10px 6px;
+    font-size: 0.8rem;
+    gap: 4px;
+    flex-direction: row;
+    white-space: nowrap;
+  }
+
+  .subject-emoji {
+    font-size: 1rem;
+  }
+
   .subject-achievement {
     padding: 4px;
   }


### PR DESCRIPTION
- 両ファイルに480pxでの.subject-btnコンパクトスタイルを追加
- padding: 10px 6px（コンパクト化）
- font-size: 0.8rem、gap: 4px（スペース節約）
- flex-direction: row、white-space: nowrap（横書き強制）
- subject-emoji: 1rem（縮小）
- これで確実に横書きになり、両方が完全一致