### PR TITLE
Fix: 480pxでのコンパクトスタイルを削除してボタンサイズ統一

### DIFF
--- a/child-learning-app/src/components/PastPaperView.css
+++ b/child-learning-app/src/components/PastPaperView.css
@@ -966,18 +966,6 @@
     gap: 10px;
   }
 
-  .subject-btn {
-    padding: 10px 6px;
-    font-size: 0.8rem;
-    gap: 4px;
-    flex-direction: row;
-    white-space: nowrap;
-  }
-
-  .subject-emoji {
-    font-size: 1rem;
-  }
-
   .view-header h2 {
     font-size: 1.3rem;
   }

--- a/child-learning-app/src/components/UnitDashboard.css
+++ b/child-learning-app/src/components/UnitDashboard.css
@@ -696,18 +696,6 @@
     gap: 10px;
   }
 
-  .subject-btn {
-    padding: 10px 6px;
-    font-size: 0.8rem;
-    gap: 4px;
-    flex-direction: row;
-    white-space: nowrap;
-  }
-
-  .subject-emoji {
-    font-size: 1rem;
-  }
-
   .subject-achievement {
     padding: 4px;
   }


### PR DESCRIPTION
- 両ファイルから480px .subject-btnスタイルを削除
- 768px(padding: 12px)または基本(padding: 16px)を適用
- これでダッシュボードと過去問のボタンサイズが完全一致
- 全画面サイズで同じスタイルに統一