### PR TITLE
Fix: フィルタカードを最上部に移動してDashboardと構造統一

### DIFF
--- a/child-learning-app/src/components/PastPaperView.jsx
+++ b/child-learning-app/src/components/PastPaperView.jsx
@@ -366,6 +366,42 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
 
   return (
     <div className="pastpaper-view">
+      {/* フィルター */}
+      <div className="view-filters">
+        <div className="filter-group">
+          <label>表示モード:</label>
+          <button
+            className={`mode-btn ${viewMode === 'school' ? 'active' : ''}`}
+            onClick={() => setViewMode('school')}
+          >
+            🏫 学校別
+          </button>
+          <button
+            className={`mode-btn ${viewMode === 'unit' ? 'active' : ''}`}
+            onClick={() => setViewMode('unit')}
+          >
+            📚 単元別
+          </button>
+        </div>
+
+        <div className="subject-buttons">
+          {subjects.map((subject) => (
+            <button
+              key={subject}
+              className={`subject-btn ${selectedSubject === subject ? 'active' : ''}`}
+              onClick={() => setSelectedSubject(subject)}
+              style={{
+                borderColor: selectedSubject === subject ? subjectColors[subject] : '#e2e8f0',
+                background: selectedSubject === subject ? `${subjectColors[subject]}15` : 'white',
+              }}
+            >
+              <span className="subject-emoji">{subjectEmojis[subject]}</span>
+              <span>{subject}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
       <div className="view-header">
         <div className="header-title-row">
           <div>
@@ -537,42 +573,6 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
           </div>
         </div>
       )}
-
-      {/* フィルター */}
-      <div className="view-filters">
-        <div className="filter-group">
-          <label>表示モード:</label>
-          <button
-            className={`mode-btn ${viewMode === 'school' ? 'active' : ''}`}
-            onClick={() => setViewMode('school')}
-          >
-            🏫 学校別
-          </button>
-          <button
-            className={`mode-btn ${viewMode === 'unit' ? 'active' : ''}`}
-            onClick={() => setViewMode('unit')}
-          >
-            📚 単元別
-          </button>
-        </div>
-
-        <div className="subject-buttons">
-          {subjects.map((subject) => (
-            <button
-              key={subject}
-              className={`subject-btn ${selectedSubject === subject ? 'active' : ''}`}
-              onClick={() => setSelectedSubject(subject)}
-              style={{
-                borderColor: selectedSubject === subject ? subjectColors[subject] : '#e2e8f0',
-                background: selectedSubject === subject ? `${subjectColors[subject]}15` : 'white',
-              }}
-            >
-              <span className="subject-emoji">{subjectEmojis[subject]}</span>
-              <span>{subject}</span>
-            </button>
-          ))}
-        </div>
-      </div>
 
       {/* タスク一覧 */}
       <div className="pastpaper-content">


### PR DESCRIPTION
- フィルタカードをコンポーネント最上部に配置
- view-header（タイトル・説明・追加ボタン）をフィルタ後に移動
- 重複していたフィルタカードを削除
- これでDashboardと同じ構造に: Filter → Content
- ユーザー指示に従い条件を統一