### PR TITLE
Fix: CSS競合を解消するためクラス名を分離

### DIFF
--- a/child-learning-app/src/components/PastPaperView.css
+++ b/child-learning-app/src/components/PastPaperView.css
@@ -153,7 +153,9 @@
   margin-bottom: 15px;
 }
 
-.subject-btn {
+/* 共通の科目ボタンスタイル */
+.subject-btn,
+.pastpaper-subject-btn {
   padding: 16px;
   border: 1px solid rgba(0, 0, 0, 0.08);
   border-radius: 14px;
@@ -171,7 +173,8 @@
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
 }
 
-.subject-btn:hover {
+.subject-btn:hover,
+.pastpaper-subject-btn:hover {
   transform: translateY(-1px);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
   border-color: rgba(0, 0, 0, 0.12);
@@ -834,7 +837,8 @@
     font-size: 0.9rem;
   }
 
-  .subject-btn {
+  .subject-btn,
+  .pastpaper-subject-btn {
     padding: 12px;
     font-size: 0.9rem;
   }

--- a/child-learning-app/src/components/PastPaperView.jsx
+++ b/child-learning-app/src/components/PastPaperView.jsx
@@ -388,7 +388,7 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
           {subjects.map((subject) => (
             <button
               key={subject}
-              className={`subject-btn ${selectedSubject === subject ? 'active' : ''}`}
+              className={`pastpaper-subject-btn ${selectedSubject === subject ? 'active' : ''}`}
               onClick={() => setSelectedSubject(subject)}
               style={{
                 borderColor: selectedSubject === subject ? subjectColors[subject] : '#e2e8f0',

--- a/child-learning-app/src/components/UnitDashboard.css
+++ b/child-learning-app/src/components/UnitDashboard.css
@@ -60,7 +60,7 @@
   gap: 12px;
 }
 
-.subject-btn {
+.dashboard-subject-btn {
   padding: 16px;
   border: 1px solid rgba(0, 0, 0, 0.08);
   border-radius: 14px;
@@ -78,7 +78,7 @@
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
 }
 
-.subject-btn:hover {
+.dashboard-subject-btn:hover {
   transform: translateY(-1px);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
   border-color: rgba(0, 0, 0, 0.12);
@@ -654,7 +654,7 @@
     font-size: 0.9rem;
   }
 
-  .subject-btn {
+  .dashboard-subject-btn {
     padding: 12px;
     font-size: 0.9rem;
   }

--- a/child-learning-app/src/components/UnitDashboard.jsx
+++ b/child-learning-app/src/components/UnitDashboard.jsx
@@ -90,7 +90,7 @@ function UnitDashboard({ tasks, onEditTask, customUnits = [] }) {
           {subjects.map((subject) => (
             <button
               key={subject}
-              className={`subject-btn ${selectedSubject === subject ? 'active' : ''}`}
+              className={`dashboard-subject-btn ${selectedSubject === subject ? 'active' : ''}`}
               onClick={() => setSelectedSubject(subject)}
               style={{
                 borderColor: selectedSubject === subject ? subjectColors[subject] : '#e2e8f0',


### PR DESCRIPTION
【問題】
- UnitDashboard.cssとPastPaperView.cssの両方で.subject-btnが定義されており、 ビルド時のCSS結合順序により、ダッシュボードで768pxメディアクエリが 正しく適用されない問題が発生

【解決策】
- UnitDashboard: .subject-btn → .dashboard-subject-btn
- PastPaperView（フィルタ）: .subject-btn → .pastpaper-subject-btn
- PastPaperView（フォーム）: .subject-btn（維持）

【効果】
- クラス名の衝突を解消し、各コンポーネントで独立したスタイル適用
- メディアクエリが正しく適用され、モバイル表示が統一される