### PR TITLE
Fix: すべてのflexプロパティをインラインで明示的に指定

### DIFF
--- a/child-learning-app/src/components/PastPaperView.jsx
+++ b/child-learning-app/src/components/PastPaperView.jsx
@@ -395,6 +395,12 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
                 background: selectedSubject === subject ? `${subjectColors[subject]}15` : 'white',
                 padding: '12px',
                 fontSize: '0.9rem',
+                display: 'flex',
+                flexDirection: 'row',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: '10px',
+                whiteSpace: 'nowrap',
               }}
             >
               <span className="subject-emoji">{subjectEmojis[subject]}</span>

--- a/child-learning-app/src/components/UnitDashboard.jsx
+++ b/child-learning-app/src/components/UnitDashboard.jsx
@@ -97,6 +97,12 @@ function UnitDashboard({ tasks, onEditTask, customUnits = [] }) {
                 background: selectedSubject === subject ? `${subjectColors[subject]}15` : 'white',
                 padding: '12px',
                 fontSize: '0.9rem',
+                display: 'flex',
+                flexDirection: 'row',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: '10px',
+                whiteSpace: 'nowrap',
               }}
             >
               <span className="subject-emoji">{subjectEmojis[subject]}</span>


### PR DESCRIPTION
- 縦書き問題を解決するためflexDirection: 'row'を追加
- テキスト改行を防ぐためwhiteSpace: 'nowrap'を追加
- display, alignItems, justifyContent, gapもインラインで指定
- CSSファイルの影響を完全に排除してレイアウトを統一