### PR TITLE
Fix: フィルターカードの余白を完全統一

### DIFF
--- a/child-learning-app/src/components/PastPaperView.jsx
+++ b/child-learning-app/src/components/PastPaperView.jsx
@@ -367,7 +367,14 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
   return (
     <div className="pastpaper-view">
       {/* フィルター */}
-      <div className="view-filters">
+      <div className="view-filters" style={{
+        background: 'white',
+        borderRadius: '20px',
+        padding: '12px',
+        marginBottom: '24px',
+        boxShadow: '0 2px 12px rgba(0, 0, 0, 0.04), 0 1px 4px rgba(0, 0, 0, 0.06)',
+        border: '1px solid rgba(0, 0, 0, 0.04)',
+      }}>
         <div className="filter-group">
           <label>表示モード:</label>
           <button

--- a/child-learning-app/src/components/UnitDashboard.jsx
+++ b/child-learning-app/src/components/UnitDashboard.jsx
@@ -72,7 +72,14 @@ function UnitDashboard({ tasks, onEditTask, customUnits = [] }) {
   return (
     <div className="unit-dashboard">
       {/* ヘッダー：学年・科目選択 */}
-      <div className="dashboard-header">
+      <div className="dashboard-header" style={{
+        background: 'white',
+        borderRadius: '20px',
+        padding: '12px',
+        marginBottom: '24px',
+        boxShadow: '0 2px 12px rgba(0, 0, 0, 0.04), 0 1px 4px rgba(0, 0, 0, 0.06)',
+        border: '1px solid rgba(0, 0, 0, 0.04)',
+      }}>
         <div className="grade-selector">
           <label>学年:</label>
           {grades.map((grade) => (


### PR DESCRIPTION
- 両方のカードに同じインラインスタイルを適用
- padding, margin, boxShadow, borderを明示的に指定
- CSSファイルの影響を完全に排除