### PR TITLE
Fix: ラベルとボタンに完全なインラインスタイルを適用して間隔を統一

### DIFF
--- a/child-learning-app/src/components/PastPaperView.jsx
+++ b/child-learning-app/src/components/PastPaperView.jsx
@@ -382,17 +382,40 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
           gap: '12px',
           marginBottom: '40px',
           flexWrap: 'wrap',
+          minHeight: '40px',
         }}>
-          <label>表示モード:</label>
+          <label style={{
+            fontWeight: '600',
+            color: '#1d1d1f',
+            fontSize: '0.9375rem',
+            letterSpacing: '-0.01em',
+            margin: '0',
+            padding: '0',
+            lineHeight: '1.5',
+          }}>表示モード:</label>
           <button
             className={`mode-btn ${viewMode === 'school' ? 'active' : ''}`}
             onClick={() => setViewMode('school')}
+            style={{
+              padding: '8px 16px',
+              fontSize: '0.9rem',
+              fontWeight: '600',
+              lineHeight: '1.5',
+              margin: '0',
+            }}
           >
             学校別
           </button>
           <button
             className={`mode-btn ${viewMode === 'unit' ? 'active' : ''}`}
             onClick={() => setViewMode('unit')}
+            style={{
+              padding: '8px 16px',
+              fontSize: '0.9rem',
+              fontWeight: '600',
+              lineHeight: '1.5',
+              margin: '0',
+            }}
           >
             単元別
           </button>

--- a/child-learning-app/src/components/UnitDashboard.jsx
+++ b/child-learning-app/src/components/UnitDashboard.jsx
@@ -87,13 +87,29 @@ function UnitDashboard({ tasks, onEditTask, customUnits = [] }) {
           gap: '12px',
           marginBottom: '40px',
           flexWrap: 'wrap',
+          minHeight: '40px',
         }}>
-          <label>学年:</label>
+          <label style={{
+            fontWeight: '600',
+            color: '#1d1d1f',
+            fontSize: '0.9375rem',
+            letterSpacing: '-0.01em',
+            margin: '0',
+            padding: '0',
+            lineHeight: '1.5',
+          }}>学年:</label>
           {grades.map((grade) => (
             <button
               key={grade}
               className={`grade-btn ${selectedGrade === grade ? 'active' : ''}`}
               onClick={() => setSelectedGrade(grade)}
+              style={{
+                padding: '8px 16px',
+                fontSize: '0.9rem',
+                fontWeight: '600',
+                lineHeight: '1.5',
+                margin: '0',
+              }}
             >
               {grade}
             </button>


### PR DESCRIPTION
- 選択エリアにminHeight: 40pxを追加して高さを統一
- ラベル要素にfont、margin、padding、lineHeightを明示的に指定
- 選択ボタンにpadding、fontSize、lineHeightを明示的に指定
- これによりflexboxの高さ計算が両方で同じになり、間隔が統一される