### PR TITLE
Fix: コンテナ高さを固定して間隔を完全統一

### DIFF
--- a/child-learning-app/src/components/PastPaperView.jsx
+++ b/child-learning-app/src/components/PastPaperView.jsx
@@ -382,7 +382,8 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
           gap: '12px',
           marginBottom: '40px',
           flexWrap: 'wrap',
-          minHeight: '40px',
+          height: '80px',
+          alignContent: 'center',
         }}>
           <label style={{
             fontWeight: '600',

--- a/child-learning-app/src/components/UnitDashboard.jsx
+++ b/child-learning-app/src/components/UnitDashboard.jsx
@@ -87,7 +87,8 @@ function UnitDashboard({ tasks, onEditTask, customUnits = [] }) {
           gap: '12px',
           marginBottom: '40px',
           flexWrap: 'wrap',
-          minHeight: '40px',
+          height: '80px',
+          alignContent: 'center',
         }}>
           <label style={{
             fontWeight: '600',


### PR DESCRIPTION
根本原因:
- minHeightでは実際の高さが異なる（1行 vs 2行）
- marginBottomは底から測定されるため、高さが異なると視覚的間隔も異なる

解決策:
- height: 80pxで両方を固定の同じ高さに設定
- alignContent: centerでコンテンツを垂直中央配置
- これにより両方のmarginBottomが同じ垂直位置から開始