### PR TITLE
Fix: 間隔測定を科目ボタン側に変更して完全統一

### DIFF
--- a/child-learning-app/src/components/PastPaperView.jsx
+++ b/child-learning-app/src/components/PastPaperView.jsx
@@ -380,10 +380,8 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
           alignItems: 'center',
           justifyContent: 'center',
           gap: '12px',
-          marginBottom: '40px',
+          marginBottom: '0',
           flexWrap: 'wrap',
-          height: '80px',
-          alignContent: 'center',
         }}>
           <label style={{
             fontWeight: '600',
@@ -426,6 +424,7 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
           display: 'grid',
           gridTemplateColumns: 'repeat(4, 1fr)',
           gap: '12px',
+          marginTop: '40px',
         }}>
           {subjects.map((subject) => (
             <button

--- a/child-learning-app/src/components/UnitDashboard.jsx
+++ b/child-learning-app/src/components/UnitDashboard.jsx
@@ -85,10 +85,8 @@ function UnitDashboard({ tasks, onEditTask, customUnits = [] }) {
           alignItems: 'center',
           justifyContent: 'center',
           gap: '12px',
-          marginBottom: '40px',
+          marginBottom: '0',
           flexWrap: 'wrap',
-          height: '80px',
-          alignContent: 'center',
         }}>
           <label style={{
             fontWeight: '600',
@@ -121,6 +119,7 @@ function UnitDashboard({ tasks, onEditTask, customUnits = [] }) {
           display: 'grid',
           gridTemplateColumns: 'repeat(4, 1fr)',
           gap: '12px',
+          marginTop: '40px',
         }}>
           {subjects.map((subject) => (
             <button


### PR DESCRIPTION
根本原因の解決:
- 従来: 選択エリアのmarginBottom（下から測定） → コンテナ高さが異なると間隔も異なる

新アプローチ: 科目ボタンのmarginTop（上から測定）
- 選択エリアの高さは自然なまま（制限なし）
- 科目ボタンが常に40px上に配置
- 選択エリアが1行でも2行でも、間隔は同じ40px

変更:
- 選択エリア: marginBottom: 0, height削除
- 科目ボタン: marginTop: 40px追加