### PR TITLE
Fix: CSSファイルを直接変更して間隔を完全統一

### DIFF
--- a/child-learning-app/src/components/PastPaperView.css
+++ b/child-learning-app/src/components/PastPaperView.css
@@ -290,7 +290,7 @@
   align-items: center;
   justify-content: center;
   gap: 12px;
-  margin-bottom: 20px;
+  margin-bottom: 0;
   flex-wrap: wrap;
 }
 
@@ -331,6 +331,7 @@
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 12px;
+  margin-top: 40px;
 }
 
 /* コンテンツ */

--- a/child-learning-app/src/components/UnitDashboard.css
+++ b/child-learning-app/src/components/UnitDashboard.css
@@ -17,7 +17,7 @@
   align-items: center;
   justify-content: center;
   gap: 12px;
-  margin-bottom: 20px;
+  margin-bottom: 0;
   flex-wrap: wrap;
 }
 
@@ -58,6 +58,7 @@
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 12px;
+  margin-top: 40px;
 }
 
 .dashboard-subject-btn {


### PR DESCRIPTION
根本原因:
- インラインスタイルだけでなくCSS側も変更が必要
- CSS specificity や margin collapsing を完全に排除

変更:
UnitDashboard.css:
- .grade-selector: margin-bottom: 20px → 0
- .subject-selector: margin-top: 40px 追加

PastPaperView.css:
- .filter-group: margin-bottom: 20px → 0
- .subject-buttons: margin-top: 40px 追加

これでインラインスタイルとCSS両方で同じ設定になり、
確実に40pxの間隔が両方に適用される