### PR TITLE
Test: CSSクラスを削除して完全インラインスタイル化

### DIFF
--- a/child-learning-app/src/components/PastPaperView.jsx
+++ b/child-learning-app/src/components/PastPaperView.jsx
@@ -375,7 +375,7 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
         boxShadow: '0 2px 12px rgba(0, 0, 0, 0.04), 0 1px 4px rgba(0, 0, 0, 0.06)',
         border: '1px solid rgba(0, 0, 0, 0.04)',
       }}>
-        <div className="filter-group" style={{
+        <div style={{
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
@@ -383,6 +383,8 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
           marginBottom: '0',
           flexWrap: 'wrap',
           border: '2px solid red',
+          boxSizing: 'border-box',
+          padding: '0',
         }}>
           <label style={{
             fontWeight: '600',
@@ -421,12 +423,15 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
           </button>
         </div>
 
-        <div className="subject-buttons" style={{
+        <div style={{
           display: 'grid',
           gridTemplateColumns: 'repeat(4, 1fr)',
           gap: '12px',
           marginTop: '40px',
           border: '2px solid blue',
+          boxSizing: 'border-box',
+          padding: '0',
+          marginBottom: '0',
         }}>
           {subjects.map((subject) => (
             <button

--- a/child-learning-app/src/components/UnitDashboard.jsx
+++ b/child-learning-app/src/components/UnitDashboard.jsx
@@ -80,7 +80,7 @@ function UnitDashboard({ tasks, onEditTask, customUnits = [] }) {
         boxShadow: '0 2px 12px rgba(0, 0, 0, 0.04), 0 1px 4px rgba(0, 0, 0, 0.06)',
         border: '1px solid rgba(0, 0, 0, 0.04)',
       }}>
-        <div className="grade-selector" style={{
+        <div style={{
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
@@ -88,6 +88,8 @@ function UnitDashboard({ tasks, onEditTask, customUnits = [] }) {
           marginBottom: '0',
           flexWrap: 'wrap',
           border: '2px solid red',
+          boxSizing: 'border-box',
+          padding: '0',
         }}>
           <label style={{
             fontWeight: '600',
@@ -116,12 +118,15 @@ function UnitDashboard({ tasks, onEditTask, customUnits = [] }) {
           ))}
         </div>
 
-        <div className="subject-selector" style={{
+        <div style={{
           display: 'grid',
           gridTemplateColumns: 'repeat(4, 1fr)',
           gap: '12px',
           marginTop: '40px',
           border: '2px solid blue',
+          boxSizing: 'border-box',
+          padding: '0',
+          marginBottom: '0',
         }}>
           {subjects.map((subject) => (
             <button


### PR DESCRIPTION
変更:
- className="grade-selector" / "filter-group" を削除
- className="subject-selector" / "subject-buttons" を削除
- boxSizing: border-box を追加
- padding: 0, marginBottom: 0 を明示的に指定

これでCSS側の影響を完全に排除し、
インラインスタイルのみで動作するようになる