### PR TITLE
完全再構築: すべてをゼロから作り直し

### DIFF
--- a/child-learning-app/src/components/PastPaperView.css
+++ b/child-learning-app/src/components/PastPaperView.css
@@ -285,6 +285,35 @@
   border: 1px solid rgba(0, 0, 0, 0.04);
 }
 
+/* 共通スタイル */
+.selection-area {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  flex-wrap: wrap;
+}
+
+.selection-area label {
+  font-weight: 600;
+  color: #1d1d1f;
+  font-size: 0.9375rem;
+  letter-spacing: -0.01em;
+  margin: 0;
+  padding: 0;
+}
+
+.subject-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+  margin-top: 40px;
+  margin-bottom: 0;
+  padding: 0;
+}
+
 .filter-group {
   display: flex;
   align-items: center;

--- a/child-learning-app/src/components/PastPaperView.jsx
+++ b/child-learning-app/src/components/PastPaperView.jsx
@@ -367,75 +367,24 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
   return (
     <div className="pastpaper-view">
       {/* フィルター */}
-      <div className="view-filters" style={{
-        background: 'white',
-        borderRadius: '20px',
-        padding: '12px',
-        marginBottom: '24px',
-        boxShadow: '0 2px 12px rgba(0, 0, 0, 0.04), 0 1px 4px rgba(0, 0, 0, 0.06)',
-        border: '1px solid rgba(0, 0, 0, 0.04)',
-      }}>
-        <div style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          gap: '12px',
-          marginBottom: '0',
-          flexWrap: 'wrap',
-          border: '2px solid red',
-          boxSizing: 'border-box',
-          padding: '8px 0',
-          height: '70px',
-          alignContent: 'center',
-        }}>
-          <label style={{
-            fontWeight: '600',
-            color: '#1d1d1f',
-            fontSize: '0.9375rem',
-            letterSpacing: '-0.01em',
-            margin: '0',
-            padding: '0',
-            lineHeight: '1.5',
-          }}>表示モード:</label>
+      <div className="view-filters">
+        <div className="selection-area">
+          <label>表示モード:</label>
           <button
             className={`mode-btn ${viewMode === 'school' ? 'active' : ''}`}
             onClick={() => setViewMode('school')}
-            style={{
-              padding: '8px 16px',
-              fontSize: '0.9rem',
-              fontWeight: '600',
-              lineHeight: '1.5',
-              margin: '0',
-            }}
           >
             学校別
           </button>
           <button
             className={`mode-btn ${viewMode === 'unit' ? 'active' : ''}`}
             onClick={() => setViewMode('unit')}
-            style={{
-              padding: '8px 16px',
-              fontSize: '0.9rem',
-              fontWeight: '600',
-              lineHeight: '1.5',
-              margin: '0',
-            }}
           >
             単元別
           </button>
         </div>
 
-        <div style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(4, 1fr)',
-          gap: '12px',
-          paddingTop: '40px',
-          marginTop: '0',
-          border: '2px solid blue',
-          boxSizing: 'border-box',
-          padding: '40px 0 0 0',
-          marginBottom: '0',
-        }}>
+        <div className="subject-grid">
           {subjects.map((subject) => (
             <button
               key={subject}

--- a/child-learning-app/src/components/UnitDashboard.css
+++ b/child-learning-app/src/components/UnitDashboard.css
@@ -12,6 +12,35 @@
   border: 1px solid rgba(0, 0, 0, 0.04);
 }
 
+/* 共通スタイル */
+.selection-area {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  flex-wrap: wrap;
+}
+
+.selection-area label {
+  font-weight: 600;
+  color: #1d1d1f;
+  font-size: 0.9375rem;
+  letter-spacing: -0.01em;
+  margin: 0;
+  padding: 0;
+}
+
+.subject-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+  margin-top: 40px;
+  margin-bottom: 0;
+  padding: 0;
+}
+
 .grade-selector {
   display: flex;
   align-items: center;

--- a/child-learning-app/src/components/UnitDashboard.jsx
+++ b/child-learning-app/src/components/UnitDashboard.jsx
@@ -72,65 +72,21 @@ function UnitDashboard({ tasks, onEditTask, customUnits = [] }) {
   return (
     <div className="unit-dashboard">
       {/* ヘッダー：学年・科目選択 */}
-      <div className="dashboard-header" style={{
-        background: 'white',
-        borderRadius: '20px',
-        padding: '12px',
-        marginBottom: '24px',
-        boxShadow: '0 2px 12px rgba(0, 0, 0, 0.04), 0 1px 4px rgba(0, 0, 0, 0.06)',
-        border: '1px solid rgba(0, 0, 0, 0.04)',
-      }}>
-        <div style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          gap: '12px',
-          marginBottom: '0',
-          flexWrap: 'wrap',
-          border: '2px solid red',
-          boxSizing: 'border-box',
-          padding: '8px 0',
-          height: '70px',
-          alignContent: 'center',
-        }}>
-          <label style={{
-            fontWeight: '600',
-            color: '#1d1d1f',
-            fontSize: '0.9375rem',
-            letterSpacing: '-0.01em',
-            margin: '0',
-            padding: '0',
-            lineHeight: '1.5',
-          }}>学年:</label>
+      <div className="dashboard-header">
+        <div className="selection-area">
+          <label>学年:</label>
           {grades.map((grade) => (
             <button
               key={grade}
               className={`grade-btn ${selectedGrade === grade ? 'active' : ''}`}
               onClick={() => setSelectedGrade(grade)}
-              style={{
-                padding: '8px 16px',
-                fontSize: '0.9rem',
-                fontWeight: '600',
-                lineHeight: '1.5',
-                margin: '0',
-              }}
             >
               {grade}
             </button>
           ))}
         </div>
 
-        <div style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(4, 1fr)',
-          gap: '12px',
-          paddingTop: '40px',
-          marginTop: '0',
-          border: '2px solid blue',
-          boxSizing: 'border-box',
-          padding: '40px 0 0 0',
-          marginBottom: '0',
-        }}>
+        <div className="subject-grid">
           {subjects.map((subject) => (
             <button
               key={subject}


### PR DESCRIPTION
変更内容:
- すべての診断用境界線を削除
- すべての複雑なインラインスタイルを削除
- 共通CSSクラス .selection-area と .subject-grid を新規作成
- 両方のファイルで完全に同じCSSを使用

.selection-area:
- margin: 0, padding: 0
- display: flex, gap: 12px

.subject-grid:
- margin-top: 40px
- margin-bottom: 0, padding: 0
- display: grid

これにより、両方のコンポーネントで間隔が完全に統一される