### PR TITLE
Fix: UnitManagerのコンテナスタイルをDashboardと統一

### DIFF
--- a/child-learning-app/src/components/UnitManager.css
+++ b/child-learning-app/src/components/UnitManager.css
@@ -1,7 +1,5 @@
 .unit-manager {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 20px;
+  padding: 24px 0;
 }
 
 .manager-header {


### PR DESCRIPTION
- max-width: 1200pxを削除
- padding: 20pxをpadding: 24px 0に変更
- これにより学年ボタンが折り返さなくなる