### PR TITLE
Fix: UnitManagerにレスポンシブメディアクエリを追加

### DIFF
--- a/child-learning-app/src/components/UnitManager.css
+++ b/child-learning-app/src/components/UnitManager.css
@@ -391,6 +391,22 @@
 }
 
 /* レスポンシブ */
+@media (max-width: 2000px) {
+  .dashboard-header {
+    padding: 6px;
+  }
+
+  .grade-btn {
+    padding: 8px 16px;
+    font-size: 0.9rem;
+  }
+
+  .dashboard-subject-btn {
+    padding: 12px;
+    font-size: 0.9rem;
+  }
+}
+
 @media (max-width: 768px) {
   .unit-manager {
     padding: 15px;


### PR DESCRIPTION
- @media (max-width: 2000px)を追加
- grade-btnのpaddingを8px 16pxに削減（Dashboardと同じ）
- dashboard-subject-btnのpaddingを12pxに削減
- これにより学年ボタンが1行に収まる