### PR TITLE
Fix: 学年選択と科目選択の間隔を半分に削減

### DIFF
--- a/child-learning-app/src/components/PastPaperView.css
+++ b/child-learning-app/src/components/PastPaperView.css
@@ -309,7 +309,7 @@
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 12px;
-  margin-top: 40px;
+  margin-top: 20px;
   margin-bottom: 0;
   padding: 0;
 }

--- a/child-learning-app/src/components/UnitDashboard.css
+++ b/child-learning-app/src/components/UnitDashboard.css
@@ -36,7 +36,7 @@
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 12px;
-  margin-top: 40px;
+  margin-top: 20px;
   margin-bottom: 0;
   padding: 0;
 }

--- a/child-learning-app/src/components/UnitManager.css
+++ b/child-learning-app/src/components/UnitManager.css
@@ -50,7 +50,7 @@
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 12px;
-  margin-top: 40px;
+  margin-top: 20px;
   margin-bottom: 0;
   padding: 0;
 }


### PR DESCRIPTION
- margin-topを40pxから20pxに変更
- Dashboard、PastPaper、UnitManagerすべてで統一