### PR TITLE
Fix: 単元管理のカードサイズをDashboardと統一

### DIFF
--- a/child-learning-app/src/components/UnitManager.css
+++ b/child-learning-app/src/components/UnitManager.css
@@ -225,16 +225,18 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 15px 20px;
-  border-radius: 10px;
-  border: 2px solid #e2e8f0;
+  padding: 12px;
+  border-radius: 16px;
+  border: 1px solid rgba(0, 0, 0, 0.06);
   background: white;
   transition: all 0.3s ease;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04), 0 1px 3px rgba(0, 0, 0, 0.06);
 }
 
 .unit-item:hover {
-  border-color: #cbd5e1;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.08), 0 3px 8px rgba(0, 0, 0, 0.06);
+  border-color: rgba(0, 0, 0, 0.1);
 }
 
 .unit-item.default {


### PR DESCRIPTION
- padding: 15px 20px → 12px に削減
- border-radius: 10px → 16px に変更
- border: 2px → 1px に変更
- box-shadowをDashboardと同じスタイルに統一
- hover時の動きも統一