### PR TITLE
Fix: カード内部のレイアウトをDashboardと完全に統一

### DIFF
--- a/child-learning-app/src/components/UnitManager.css
+++ b/child-learning-app/src/components/UnitManager.css
@@ -245,25 +245,26 @@
 }
 
 .unit-info {
-  display: flex;
-  align-items: center;
-  gap: 15px;
   flex: 1;
 }
 
 .unit-name {
+  display: block;
+  font-size: 1.0625rem;
   font-weight: 600;
-  color: #1e293b;
-  font-size: 1rem;
+  color: #1d1d1f;
+  margin-bottom: 6px;
+  letter-spacing: -0.01em;
 }
 
 .unit-category {
-  padding: 4px 12px;
-  background: #e0e7ff;
-  color: #4338ca;
-  border-radius: 12px;
-  font-size: 0.85rem;
-  font-weight: 600;
+  display: inline-block;
+  font-size: 0.75rem;
+  color: #86868b;
+  background: #f5f5f7;
+  padding: 4px 10px;
+  border-radius: 8px;
+  font-weight: 500;
 }
 
 .unit-item.custom .unit-category {


### PR DESCRIPTION
- unit-infoのflexレイアウトを削除
- unit-nameをdisplay: blockに変更（縦並び）
- unit-categoryをinline-blockに変更
- フォントサイズ、padding、色をDashboardと完全に一致
- より コンパクトなカードデザインに