### PR TITLE
根本的修正: UnitManagerをDashboardの構造に完全統一

### DIFF
--- a/child-learning-app/src/components/UnitManager.css
+++ b/child-learning-app/src/components/UnitManager.css
@@ -210,7 +210,61 @@
   color: #cbd5e1;
 }
 
-/* 単元リスト */
+/* 単元グリッド（Dashboardと同じ） */
+.units-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 16px;
+}
+
+.unit-card {
+  background: white;
+  border-radius: 16px;
+  padding: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04), 0 1px 3px rgba(0, 0, 0, 0.06);
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.unit-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.08), 0 3px 8px rgba(0, 0, 0, 0.06);
+  border-color: rgba(0, 0, 0, 0.1);
+}
+
+.unit-card.custom {
+  background: #fefce8;
+  border-color: #fde047;
+}
+
+.unit-title {
+  flex: 1;
+}
+
+.unit-title .unit-name {
+  display: block;
+  font-size: 1.0625rem;
+  font-weight: 600;
+  color: #1d1d1f;
+  margin-bottom: 6px;
+  letter-spacing: -0.01em;
+}
+
+.unit-title .unit-category {
+  display: inline-block;
+  font-size: 0.75rem;
+  color: #86868b;
+  background: #f5f5f7;
+  padding: 4px 10px;
+  border-radius: 8px;
+  font-weight: 500;
+}
+
+/* 旧スタイル（編集フォーム用に保持） */
 .units-list {
   display: flex;
   flex-direction: column;

--- a/child-learning-app/src/components/UnitManager.jsx
+++ b/child-learning-app/src/components/UnitManager.jsx
@@ -110,10 +110,10 @@ function UnitManager({ customUnits, onUpdateUnit, onDeleteUnit }) {
         {defaultUnits.length === 0 ? (
           <div className="no-units">標準単元がありません</div>
         ) : (
-          <div className="units-list">
+          <div className="units-grid">
             {defaultUnits.map((unit) => (
-              <div key={unit.id} className="unit-item default">
-                <div className="unit-info">
+              <div key={unit.id} className="unit-card">
+                <div className="unit-title">
                   <span className="unit-name">{unit.name}</span>
                   <span className="unit-category">{unit.category}</span>
                 </div>
@@ -138,9 +138,9 @@ function UnitManager({ customUnits, onUpdateUnit, onDeleteUnit }) {
             <small>タスク追加画面の「➕」ボタンから追加できます</small>
           </div>
         ) : (
-          <div className="units-list">
+          <div className="units-grid">
             {filteredCustomUnits.map((unit) => (
-              <div key={unit.id} className="unit-item custom">
+              <div key={unit.id} className="unit-card custom">
                 {editingUnit && editingUnit.id === unit.id ? (
                   // 編集モード
                   <div className="unit-edit-form">
@@ -176,7 +176,7 @@ function UnitManager({ customUnits, onUpdateUnit, onDeleteUnit }) {
                 ) : (
                   // 表示モード
                   <>
-                    <div className="unit-info">
+                    <div className="unit-title">
                       <span className="unit-name">{unit.name}</span>
                       <span className="unit-category">{unit.category}</span>
                     </div>


### PR DESCRIPTION
- units-list → units-grid に変更（gridレイアウト）
- unit-item → unit-card に変更
- unit-info → unit-title に変更
- Dashboard と完全に同じCSSクラスを使用
- grid-template-columns: repeat(auto-fill, minmax(320px, 1fr))