### PR TITLE
Fix: 重複したCSS定義を削除して縦書き問題を解決

### DIFF
--- a/child-learning-app/src/components/UnitManager.css
+++ b/child-learning-app/src/components/UnitManager.css
@@ -264,68 +264,6 @@
   font-weight: 500;
 }
 
-/* 旧スタイル（編集フォーム用に保持） */
-.units-list {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.unit-item {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 12px;
-  border-radius: 16px;
-  border: 1px solid rgba(0, 0, 0, 0.06);
-  background: white;
-  transition: all 0.3s ease;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04), 0 1px 3px rgba(0, 0, 0, 0.06);
-}
-
-.unit-item:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.08), 0 3px 8px rgba(0, 0, 0, 0.06);
-  border-color: rgba(0, 0, 0, 0.1);
-}
-
-.unit-item.default {
-  background: #f8fafc;
-}
-
-.unit-item.custom {
-  background: #fefce8;
-  border-color: #fde047;
-}
-
-.unit-info {
-  flex: 1;
-}
-
-.unit-name {
-  display: block;
-  font-size: 1.0625rem;
-  font-weight: 600;
-  color: #1d1d1f;
-  margin-bottom: 6px;
-  letter-spacing: -0.01em;
-}
-
-.unit-category {
-  display: inline-block;
-  font-size: 0.75rem;
-  color: #86868b;
-  background: #f5f5f7;
-  padding: 4px 10px;
-  border-radius: 8px;
-  font-weight: 500;
-}
-
-.unit-item.custom .unit-category {
-  background: #fef3c7;
-  color: #92400e;
-}
-
 /* アクション */
 .unit-actions {
   display: flex;


### PR DESCRIPTION
- 旧スタイル（unit-item, unit-info等）を完全削除
- unit-title配下のunit-name, unit-categoryのみ保持
- CSS競合による縦書き表示を修正