### PR TITLE
Fix: 単元セクションにpaddingを追加してフィルタと幅を完全統一

### DIFF
--- a/child-learning-app/src/components/UnitManager.css
+++ b/child-learning-app/src/components/UnitManager.css
@@ -98,6 +98,7 @@
 /* 単元セクション */
 .units-section {
   margin-bottom: 20px;
+  padding: 0 12px;
 }
 
 .section-title {


### PR DESCRIPTION
問題: フィルタ部分（.dashboard-header）は12pxのpaddingでコンテンツが内側から始まるが、
      単元セクション（.units-section）にはpaddingがなく、視覚的なズレが発生

修正: .units-section に padding: 0 12px; を追加して、
      フィルタ内のコンテンツと単元カードの開始位置を完全に揃えた