### PR TITLE
REBUILD: 単元セクションをフィルタと完全同一のカードスタイルに統一

### DIFF
--- a/child-learning-app/src/components/UnitManager.css
+++ b/child-learning-app/src/components/UnitManager.css
@@ -95,10 +95,14 @@
   line-height: 1;
 }
 
-/* 単元セクション */
+/* 単元セクション - Dashboardと完全統一 */
 .units-section {
-  margin-bottom: 20px;
-  padding: 0 12px;
+  background: white;
+  border-radius: 20px;
+  padding: 12px;
+  margin-bottom: 24px;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.04), 0 1px 4px rgba(0, 0, 0, 0.06);
+  border: 1px solid rgba(0, 0, 0, 0.04);
 }
 
 .section-title {
@@ -313,7 +317,8 @@
 
 /* レスポンシブ */
 @media (max-width: 2000px) {
-  .dashboard-header {
+  .dashboard-header,
+  .units-section {
     padding: 6px;
   }
 


### PR DESCRIPTION
根本原因の完全解析:
1. フィルタ (.dashboard-header) はpaddingが12px→6px（モバイル）に変化
2. 単元セクション (.units-section) は固定12pxのまま
3. これによりモバイルで6pxのズレが発生

完全な解決策:
- .units-section に .dashboard-header と完全同一のスタイルを適用:
  - background: white
  - border-radius: 20px
  - padding: 12px (デスクトップ) → 6px (モバイル)
  - box-shadow, border も統一
- レスポンシブ対応も完全統一: 両方とも @media (max-width: 2000px) で 6px に縮小

これによりフィルタカードと単元カードが視覚的に完全一致