### PR TITLE
根本的修正: 単元セクションを透明コンテナに変更してDashboardと完全統一

### DIFF
--- a/child-learning-app/src/components/UnitManager.css
+++ b/child-learning-app/src/components/UnitManager.css
@@ -95,29 +95,26 @@
   line-height: 1;
 }
 
-/* 単元セクション - Dashboardと完全統一 */
+/* 単元セクション - 透明なコンテナ（Dashboardと統一） */
 .units-section {
-  background: white;
-  border-radius: 20px;
-  padding: 12px;
-  margin-bottom: 24px;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.04), 0 1px 4px rgba(0, 0, 0, 0.06);
-  border: 1px solid rgba(0, 0, 0, 0.04);
+  margin-bottom: 32px;
 }
 
 .section-title {
-  color: #1e40af;
-  font-size: 1.3rem;
-  margin-bottom: 12px;
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: #1d1d1f;
+  margin-bottom: 16px;
   display: flex;
   align-items: center;
   gap: 10px;
+  letter-spacing: -0.01em;
 }
 
 .unit-count {
-  font-size: 0.9rem;
-  color: #64748b;
-  font-weight: 400;
+  font-size: 0.875rem;
+  color: #86868b;
+  font-weight: 500;
 }
 
 .no-units {
@@ -317,8 +314,7 @@
 
 /* レスポンシブ */
 @media (max-width: 2000px) {
-  .dashboard-header,
-  .units-section {
+  .dashboard-header {
     padding: 6px;
   }
 


### PR DESCRIPTION
問題の本質:
- .units-section に白背景カードスタイルを適用していたため、 単元全体が1つの大きな白カードになり、フィルタと視覚的に異なっていた

Dashboardの正しい構造:
- フィルタ: 1つの白いカード (.dashboard-header)
- 単元: 個別の白いカード (.unit-card) が並ぶ
- セクションコンテナ (.units-section) は透明

修正内容:
- .units-section から白背景、padding、box-shadow、border を削除
- margin-bottom: 32px のみ残す（セクション間隔）
- .section-title のスタイルを調整（独立したヘッダーとして）
- レスポンシブ対応から .units-section を削除

結果: フィルタカードと単元カードが完全に同じ視覚的重みで表示される