### PR TITLE
CRITICAL FIX: 単元セクションにpaddingを追加してフィルタコンテンツと完全整列

### DIFF
--- a/child-learning-app/src/components/UnitManager.css
+++ b/child-learning-app/src/components/UnitManager.css
@@ -95,9 +95,10 @@
   line-height: 1;
 }
 
-/* 単元セクション - 透明なコンテナ（Dashboardと統一） */
+/* 単元セクション - フィルタと同じpaddingで揃える */
 .units-section {
   margin-bottom: 32px;
+  padding: 0 12px;
 }
 
 .section-title {
@@ -316,6 +317,10 @@
 @media (max-width: 2000px) {
   .dashboard-header {
     padding: 6px;
+  }
+
+  .units-section {
+    padding: 0 6px;
   }
 
   .grade-btn {


### PR DESCRIPTION
根本原因:
- 前回のコミット(4a0bd2b)で.units-sectionからpaddingを削除したため、 単元カードがフィルタコンテンツより6px分左右にはみ出していた

iPhoneでの配置:
- フィルタCONTENT開始位置: 15px(unit-manager) + 6px(dashboard-header) = 21px
- 単元カード開始位置(修正前): 15px(unit-manager) + 0px = 15px ← 6pxズレ!
- 単元カード開始位置(修正後): 15px(unit-manager) + 6px(units-section) = 21px ← 完全一致!

修正内容:
- .units-section に padding: 0 12px を追加（デスクトップ）
- @media (max-width: 2000px) で padding: 0 6px に変更（モバイル）
- これにより.dashboard-headerと.units-sectionのpaddingが完全一致

結果: フィルタ内のボタンと単元カードの開始位置が完璧に揃う