### PR TITLE
Fix: 単元セクションのpaddingを削除してDashboardと幅を完全統一

### DIFF
--- a/child-learning-app/src/components/UnitManager.css
+++ b/child-learning-app/src/components/UnitManager.css
@@ -95,10 +95,9 @@
   line-height: 1;
 }
 
-/* 単元セクション - フィルタと同じpaddingで揃える */
+/* 単元セクション */
 .units-section {
   margin-bottom: 32px;
-  padding: 0 12px;
 }
 
 .section-title {
@@ -317,10 +316,6 @@
 @media (max-width: 2000px) {
   .dashboard-header {
     padding: 6px;
-  }
-
-  .units-section {
-    padding: 0 6px;
   }
 
   .grade-btn {


### PR DESCRIPTION
ダッシュボード画面の確認により判明:
- Dashboard: フィルタカード、統計カード、単元カード すべて同じ幅
- UnitManager: 単元カードだけ12px狭い（.units-section padding による）

修正:
- .units-section から padding: 0 12px を完全削除
- @media (max-width: 2000px) から .units-section の padding: 0 6px を削除

結果:
- フィルタカードと単元カードが完全に同じ幅になる
- Dashboardと完全に同じレイアウト