### PR TITLE
Fix: グリッドレイアウトをマルチカラムに変更してDashboardと完全統一

### DIFF
--- a/child-learning-app/src/components/UnitManager.css
+++ b/child-learning-app/src/components/UnitManager.css
@@ -134,9 +134,8 @@
 /* 単元グリッド */
 .units-grid {
   display: grid;
-  grid-template-columns: 1fr;
-  gap: 12px;
-  width: 100%;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 16px;
 }
 
 .unit-card {
@@ -326,6 +325,16 @@
   .dashboard-subject-btn {
     padding: 12px;
     font-size: 0.9rem;
+  }
+}
+
+@media (max-width: 1024px) {
+  .subject-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .units-grid {
+    grid-template-columns: 1fr;
   }
 }
 


### PR DESCRIPTION
修正内容:
- .units-grid を単一カラム (1fr) からマルチカラム (repeat(auto-fill, minmax(320px, 1fr))) に変更
- gap を 12px から 16px に変更
- @media (max-width: 1024px) を追加して、タブレット以下で単一カラムに切り替え
- .subject-grid も 1024px以下で2カラムに縮小

結果:
- デスクトップ: 単元カードがマルチカラムで表示（Dashboardと同じ）
- タブレット: 単一カラムに切り替わる
- モバイル: 単一カラムを維持