### PR TITLE
Fix: 科目ボタンのオーバーフローを修正 - インラインスタイルを削除してCSSメディアクエリを有効化

### DIFF
--- a/child-learning-app/src/components/UnitManager.jsx
+++ b/child-learning-app/src/components/UnitManager.jsx
@@ -85,14 +85,6 @@ function UnitManager({ customUnits, onUpdateUnit, onDeleteUnit }) {
               style={{
                 borderColor: selectedSubject === subject ? subjectColors[subject] : '#e2e8f0',
                 background: selectedSubject === subject ? `${subjectColors[subject]}15` : 'white',
-                padding: '12px',
-                fontSize: '0.9rem',
-                display: 'flex',
-                flexDirection: 'row',
-                alignItems: 'center',
-                justifyContent: 'center',
-                gap: '10px',
-                whiteSpace: 'nowrap',
               }}
             >
               <span className="subject-emoji">{subjectEmojis[subject]}</span>


### PR DESCRIPTION
問題:
- インラインスタイルでpadding: '12px'を設定していたため、CSSのメディアクエリが効かず、モバイル画面でボタンがはみ出していた

修正内容:
- padding, fontSize, display等のインラインスタイルを削除
- borderColorとbackgroundのみインラインで動的に設定
- CSSのメディアクエリでレスポンシブに対応:
  - デスクトップ: 16px padding
  - 2000px以下: 12px padding, 0.9rem font
  - 480px以下: 8px padding, 0.85rem font