### PR TITLE
Fix: UnitManagerをDashboardと完全統一 - .selection-area, .subject-gridを使用

### DIFF
--- a/child-learning-app/src/components/UnitManager.css
+++ b/child-learning-app/src/components/UnitManager.css
@@ -13,12 +13,31 @@
 }
 
 /* 共通スタイル */
+.selection-area {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  flex-wrap: wrap;
+}
+
+.selection-area label {
+  font-weight: 600;
+  color: #1d1d1f;
+  font-size: 0.9375rem;
+  letter-spacing: -0.01em;
+  margin: 0;
+  padding: 0;
+}
+
 .grade-selector {
   display: flex;
   align-items: center;
   justify-content: center;
   gap: 12px;
-  margin-bottom: 20px;
+  margin-bottom: 0;
   flex-wrap: wrap;
 }
 
@@ -55,10 +74,20 @@
   box-shadow: 0 2px 8px rgba(0, 122, 255, 0.25);
 }
 
+.subject-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+  margin-top: 20px;
+  margin-bottom: 0;
+  padding: 0;
+}
+
 .subject-selector {
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 12px;
+  margin-top: 40px;
 }
 
 .dashboard-subject-btn {

--- a/child-learning-app/src/components/UnitManager.jsx
+++ b/child-learning-app/src/components/UnitManager.jsx
@@ -63,7 +63,7 @@ function UnitManager({ customUnits, onUpdateUnit, onDeleteUnit }) {
     <div className="unit-manager">
       {/* ヘッダー：学年・科目選択 */}
       <div className="dashboard-header">
-        <div className="grade-selector">
+        <div className="selection-area">
           <label>学年:</label>
           {grades.map((grade) => (
             <button
@@ -76,7 +76,7 @@ function UnitManager({ customUnits, onUpdateUnit, onDeleteUnit }) {
           ))}
         </div>
 
-        <div className="subject-selector">
+        <div className="subject-grid">
           {subjects.map((subject) => (
             <button
               key={subject}
@@ -85,6 +85,14 @@ function UnitManager({ customUnits, onUpdateUnit, onDeleteUnit }) {
               style={{
                 borderColor: selectedSubject === subject ? subjectColors[subject] : '#e2e8f0',
                 background: selectedSubject === subject ? `${subjectColors[subject]}15` : 'white',
+                padding: '12px',
+                fontSize: '0.9rem',
+                display: 'flex',
+                flexDirection: 'row',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: '10px',
+                whiteSpace: 'nowrap',
               }}
             >
               <span className="subject-emoji">{subjectEmojis[subject]}</span>


### PR DESCRIPTION
変更内容:
1. JSX:
   - .grade-selector → .selection-area
   - .subject-selector → .subject-grid
   - インラインスタイルを完全復元 (padding, fontSize, display等)

2. CSS:
   - .selection-area スタイル追加 (margin: 0, padding: 0)
   - .subject-grid スタイル追加 (margin-top: 20px)

これによりDashboardと完全に同じクラス名・スタイルになりました。