### PR TITLE
Fix: Add missing 2000px media query from Dashboard

### DIFF
--- a/child-learning-app/src/components/UnitManager.css
+++ b/child-learning-app/src/components/UnitManager.css
@@ -330,6 +330,26 @@
 }
 
 /* レスポンシブ */
+@media (max-width: 2000px) {
+  .dashboard-header {
+    padding: 6px;
+  }
+
+  .grade-selector {
+    flex-wrap: wrap;
+  }
+
+  .grade-btn {
+    padding: 8px 16px;
+    font-size: 0.9rem;
+  }
+
+  .dashboard-subject-btn {
+    padding: 12px;
+    font-size: 0.9rem;
+  }
+}
+
 @media (max-width: 1024px) {
   .subject-grid {
     grid-template-columns: repeat(2, 1fr);


### PR DESCRIPTION
This was the root cause of button size differences on iPhone. Dashboard has this media query to reduce padding and button sizes, but UnitManager was completely missing it.

Added:
- .dashboard-header { padding: 6px }
- .grade-btn { padding: 8px 16px; font-size: 0.9rem }
- .dashboard-subject-btn { padding: 12px; font-size: 0.9rem }
- .grade-selector { flex-wrap: wrap }

Ordered correctly: 2000px → 1024px → 768px → 480px