### PR TITLE
Fix: メディアクエリが実際のJSXクラス名と不一致だった根本原因を修正

### DIFF
--- a/child-learning-app/src/components/UnitDashboard.css
+++ b/child-learning-app/src/components/UnitDashboard.css
@@ -675,13 +675,17 @@
     padding: 6px;
   }
 
-  .grade-selector {
+  .selection-area {
     flex-wrap: wrap;
   }
 
   .grade-btn {
     padding: 8px 16px;
     font-size: 0.9rem;
+  }
+
+  .subject-grid {
+    gap: 10px;
   }
 
   .dashboard-subject-btn {
@@ -712,7 +716,7 @@
     padding: 4px;
   }
 
-  .grade-selector {
+  .selection-area {
     gap: 8px;
   }
 
@@ -721,9 +725,9 @@
     font-size: 0.85rem;
   }
 
-  .subject-selector {
+  .subject-grid {
     grid-template-columns: repeat(4, 1fr);
-    gap: 10px;
+    gap: 8px;
   }
 
   .subject-achievement {

--- a/child-learning-app/src/components/UnitManager.css
+++ b/child-learning-app/src/components/UnitManager.css
@@ -335,13 +335,17 @@
     padding: 6px;
   }
 
-  .grade-selector {
+  .selection-area {
     flex-wrap: wrap;
   }
 
   .grade-btn {
     padding: 8px 16px;
     font-size: 0.9rem;
+  }
+
+  .subject-grid {
+    gap: 10px;
   }
 
   .dashboard-subject-btn {
@@ -391,7 +395,7 @@
 
   .subject-grid {
     grid-template-columns: repeat(4, 1fr);
-    gap: 10px;
+    gap: 8px;
   }
 
   .section-title {


### PR DESCRIPTION
【重大なバグ】
- JSXは className="selection-area" と "subject-grid" を使用
- しかしCSSメディアクエリは .grade-selector と .subject-selector をターゲット
- そのため2000pxと480pxのメディアクエリが適用されず、iPhoneでボタンがはみ出していた

【修正内容】
両ファイル (UnitManager.css, UnitDashboard.css):
1. @media 2000px: .grade-selector → .selection-area
2. @media 2000px: .subject-grid { gap: 10px } を追加
3. @media 480px: .grade-selector → .selection-area
4. @media 480px: .subject-selector → .subject-grid
5. gap値を統一: 480pxで8pxに統一

これでiPhoneでも正しくメディアクエリが適用され、ボタンサイズとgapが縮小される