### PR TITLE
Fix: !importantでインラインスタイルを強制上書き - iPhone対応

### DIFF
--- a/child-learning-app/src/components/UnitDashboard.css
+++ b/child-learning-app/src/components/UnitDashboard.css
@@ -730,6 +730,11 @@
     gap: 8px;
   }
 
+  .dashboard-subject-btn {
+    padding: 8px !important;
+    font-size: 0.85rem !important;
+  }
+
   .subject-achievement {
     padding: 4px;
   }

--- a/child-learning-app/src/components/UnitManager.css
+++ b/child-learning-app/src/components/UnitManager.css
@@ -398,6 +398,11 @@
     gap: 8px;
   }
 
+  .dashboard-subject-btn {
+    padding: 8px !important;
+    font-size: 0.85rem !important;
+  }
+
   .section-title {
     font-size: 1rem;
     margin-bottom: 12px;


### PR DESCRIPTION
【問題】
JSXのインラインスタイル padding: '12px' がCSSメディアクエリより優先度が高く、 480pxメディアクエリでpaddingを縮小できなかった

【解決】
480pxメディアクエリに追加:
.dashboard-subject-btn {
  padding: 8px !important;
  font-size: 0.85rem !important;
}

!importantでインラインスタイルを強制上書きし、iPhone(375px)で:
- 科目ボタンpadding: 12px → 8px
- font-size: 0.9rem → 0.85rem
- これで4列グリッドでも収まる