### PR TITLE
Fix: DashboardとCSS定義順序を完全一致 - メディアクエリ1024px→2000px→480pxの順序に変更

### DIFF
--- a/child-learning-app/src/components/UnitManager.css
+++ b/child-learning-app/src/components/UnitManager.css
@@ -329,7 +329,17 @@
   border-color: #cbd5e1;
 }
 
-/* レスポンシブ */
+/* レスポンシブ - Dashboardから完全移植 */
+@media (max-width: 1024px) {
+  .subject-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .units-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (max-width: 2000px) {
   .dashboard-header {
     padding: 6px;
@@ -351,16 +361,6 @@
   .dashboard-subject-btn {
     padding: 12px;
     font-size: 0.9rem;
-  }
-}
-
-@media (max-width: 1024px) {
-  .subject-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  .units-grid {
-    grid-template-columns: 1fr;
   }
 }
 


### PR DESCRIPTION
【重要な変更】
メディアクエリの順序をDashboardと完全一致:
- Before: 2000px → 1024px → 768px → 480px
- After:  1024px → 2000px → 768px → 480px

CSSカスケードで後のルールが優先されるため、順序が重要。
Dashboardと同じ順序にすることで、完全に同じ動作を保証。