### PR TITLE
Fix: UnitManagerを最小構成に簡略化 - ヘッダー検証用

### DIFF
--- a/child-learning-app/src/components/UnitManager.jsx
+++ b/child-learning-app/src/components/UnitManager.jsx
@@ -6,62 +6,17 @@ import { subjectEmojis, subjectColors } from '../utils/constants'
 function UnitManager({ customUnits, onUpdateUnit, onDeleteUnit }) {
   const [selectedGrade, setSelectedGrade] = useState('4年生')
   const [selectedSubject, setSelectedSubject] = useState('算数')
-  const [editingUnit, setEditingUnit] = useState(null)
-  const [editForm, setEditForm] = useState({ name: '', category: '' })
 
   // デフォルト単元とカスタム単元を統合
   const defaultUnits = unitsDatabase[selectedSubject]?.[selectedGrade] || []
   const filteredCustomUnits = customUnits.filter(
     u => u.subject === selectedSubject && u.grade === selectedGrade
   )
-
-  const handleEditClick = (unit) => {
-    setEditingUnit(unit)
-    setEditForm({ name: unit.name, category: unit.category })
-  }
-
-  const handleCancelEdit = () => {
-    setEditingUnit(null)
-    setEditForm({ name: '', category: '' })
-  }
-
-  const handleSaveEdit = async () => {
-    if (!editForm.name.trim()) {
-      alert('単元名を入力してください')
-      return
-    }
-
-    const result = await onUpdateUnit(editingUnit.firestoreId, {
-      name: editForm.name.trim(),
-      category: editForm.category,
-    })
-
-    if (result.success) {
-      alert('✅ 単元を更新しました')
-      setEditingUnit(null)
-      setEditForm({ name: '', category: '' })
-    } else {
-      alert('❌ 更新に失敗しました: ' + result.error)
-    }
-  }
-
-  const handleDelete = async (unit) => {
-    if (!window.confirm(`「${unit.name}」を削除しますか？\n\nこの操作は取り消せません。`)) {
-      return
-    }
-
-    const result = await onDeleteUnit(unit.firestoreId)
-
-    if (result.success) {
-      alert('✅ 単元を削除しました')
-    } else {
-      alert('❌ 削除に失敗しました: ' + result.error)
-    }
-  }
+  const currentUnits = [...defaultUnits, ...filteredCustomUnits]
 
   return (
     <div className="unit-manager">
-      {/* ヘッダー：学年・科目選択 */}
+      {/* ヘッダー：学年・科目選択 - Dashboardから完全コピー */}
       <div className="dashboard-header">
         <div className="selection-area">
           <label>学年:</label>
@@ -102,106 +57,26 @@ function UnitManager({ customUnits, onUpdateUnit, onDeleteUnit }) {
         </div>
       </div>
 
-      {/* デフォルト単元セクション */}
-      <div className="units-section">
-        <h3 className="section-title">
-          📋 標準単元 <span className="unit-count">({defaultUnits.length}件)</span>
-        </h3>
-        {defaultUnits.length === 0 ? (
-          <div className="no-units">標準単元がありません</div>
-        ) : (
-          <div className="units-list">
-            {defaultUnits.map((unit) => (
-              <div key={unit.id} className="unit-item default">
-                <div className="unit-info">
+      {/* 単元グリッド - Dashboardから完全コピー */}
+      <div className="units-grid">
+        {currentUnits.map((unit) => {
+          const unitBackgroundColor = `${subjectColors[selectedSubject]}26`
+
+          return (
+            <div
+              key={unit.id}
+              className="unit-card"
+              style={{ backgroundColor: unitBackgroundColor }}
+            >
+              <div className="unit-header">
+                <div className="unit-title">
                   <span className="unit-name">{unit.name}</span>
                   <span className="unit-category">{unit.category}</span>
                 </div>
-                <div className="unit-actions">
-                  <span className="default-badge">標準</span>
-                </div>
               </div>
-            ))}
-          </div>
-        )}
-      </div>
-
-      {/* カスタム単元セクション */}
-      <div className="units-section">
-        <h3 className="section-title">
-          ➕ カスタム単元 <span className="unit-count">({filteredCustomUnits.length}件)</span>
-        </h3>
-        {filteredCustomUnits.length === 0 ? (
-          <div className="no-units">
-            カスタム単元がありません
-            <br />
-            <small>タスク追加画面の「➕」ボタンから追加できます</small>
-          </div>
-        ) : (
-          <div className="units-list">
-            {filteredCustomUnits.map((unit) => (
-              <div key={unit.id} className="unit-item custom">
-                {editingUnit && editingUnit.id === unit.id ? (
-                  // 編集モード
-                  <div className="unit-edit-form">
-                    <div className="edit-fields">
-                      <input
-                        type="text"
-                        value={editForm.name}
-                        onChange={(e) => setEditForm({ ...editForm, name: e.target.value })}
-                        placeholder="単元名"
-                        className="edit-input"
-                      />
-                      <select
-                        value={editForm.category}
-                        onChange={(e) => setEditForm({ ...editForm, category: e.target.value })}
-                        className="edit-select"
-                      >
-                        <option value="過去問">過去問</option>
-                        <option value="弱点対策">弱点対策</option>
-                        <option value="発展">発展</option>
-                        <option value="特訓">特訓</option>
-                        <option value="その他">その他</option>
-                      </select>
-                    </div>
-                    <div className="edit-actions">
-                      <button className="save-btn" onClick={handleSaveEdit}>
-                        ✓ 保存
-                      </button>
-                      <button className="cancel-btn" onClick={handleCancelEdit}>
-                        ✕ キャンセル
-                      </button>
-                    </div>
-                  </div>
-                ) : (
-                  // 表示モード
-                  <>
-                    <div className="unit-info">
-                      <span className="unit-name">{unit.name}</span>
-                      <span className="unit-category">{unit.category}</span>
-                    </div>
-                    <div className="unit-actions">
-                      <button
-                        className="edit-btn"
-                        onClick={() => handleEditClick(unit)}
-                        title="編集"
-                      >
-                        ✏️
-                      </button>
-                      <button
-                        className="delete-btn"
-                        onClick={() => handleDelete(unit)}
-                        title="削除"
-                      >
-                        🗑️
-                      </button>
-                    </div>
-                  </>
-                )}
-              </div>
-            ))}
-          </div>
-        )}
+            </div>
+          )
+        })}
       </div>
     </div>
   )


### PR DESCRIPTION
標準単元・カスタム単元セクションを削除し、Dashboardと同じ構造に:
- ヘッダー: Dashboardと完全同一
- 単元表示: units-gridとunit-cardのみのシンプル構造
- 編集機能: すべて削除

ヘッダーのボタン表示を検証するための最小構成。