### PR TITLE
Fix: ページ全体の横幅制約を追加 - 単元管理タブでの横スクロール問題を解決

### DIFF
--- a/child-learning-app/src/App.css
+++ b/child-learning-app/src/App.css
@@ -9,12 +9,16 @@ body {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Helvetica Neue', Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  overflow-x: hidden;
+  width: 100%;
 }
 
 .app.sapix-theme {
   min-height: 100vh;
   background: #f5f5f7;
   padding: 24px;
+  width: 100%;
+  overflow-x: hidden;
 }
 
 .app-header {
@@ -64,6 +68,8 @@ body {
 .container {
   max-width: 1200px;
   margin: 0 auto;
+  width: 100%;
+  overflow-x: hidden;
 }
 
 .sample-schedule-prompt {


### PR DESCRIPTION
- body, .app.sapix-theme, .container に overflow-x: hidden と width: 100% を追加
- モバイル表示時にコンテンツが画面幅を超えて表示される問題を修正
- これにより、すべてのタブで一貫した幅制約が適用される