### PR TITLE
Fix: テスト成績ページの学年ボタンをダッシュボードと統一

### DIFF
--- a/child-learning-app/src/components/TestScoreView.css
+++ b/child-learning-app/src/components/TestScoreView.css
@@ -45,32 +45,35 @@
 
 .grade-buttons {
   display: flex;
-  gap: 10px;
+  gap: 12px;
   flex-wrap: wrap;
 }
 
-.filter-btn {
-  padding: 10px 20px;
-  border: 2px solid #e2e8f0;
+/* ダッシュボードと統一された学年ボタンスタイル */
+.grade-btn {
+  padding: 10px 18px;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 10px;
   background: white;
-  border-radius: 8px;
-  cursor: pointer;
-  font-size: 0.95rem;
+  font-size: 0.9375rem;
   font-weight: 600;
-  transition: all 0.3s ease;
-  color: #475569;
+  cursor: pointer;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  color: #86868b;
+  letter-spacing: -0.01em;
 }
 
-.filter-btn:hover {
-  border-color: #cbd5e1;
-  transform: translateY(-2px);
+.grade-btn:hover {
+  border-color: #007AFF;
+  background: rgba(0, 122, 255, 0.08);
+  transform: scale(1.02);
 }
 
-.filter-btn.active {
-  background: #3b82f6;
+.grade-btn.active {
+  border-color: #007AFF;
+  background: #007AFF;
   color: white;
-  border-color: #3b82f6;
-  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
+  box-shadow: 0 2px 8px rgba(0, 122, 255, 0.25);
 }
 
 .add-score-btn {

--- a/child-learning-app/src/components/TestScoreView.jsx
+++ b/child-learning-app/src/components/TestScoreView.jsx
@@ -138,7 +138,7 @@ function TestScoreView({ user }) {
             {grades.map((grade) => (
               <button
                 key={grade}
-                className={`filter-btn ${selectedGrade === grade ? 'active' : ''}`}
+                className={`grade-btn ${selectedGrade === grade ? 'active' : ''}`}
                 onClick={() => setSelectedGrade(grade)}
               >
                 {grade}


### PR DESCRIPTION
## 変更内容
- **TestScoreView.jsx**: ボタンのクラス名を `filter-btn` から `grade-btn` に変更
- **TestScoreView.css**: 学年ボタンのスタイルをダッシュボード（UnitDashboard/UnitManager）と統一

## デザイン変更
### 変更前 (filter-btn)
- 青色のアクティブ状態 (#3b82f6)
- 太めのボーダー (2px)
- 縦方向の移動アニメーション

### 変更後 (grade-btn)
- AppleスタイルのBlue (#007AFF)
- 細めのボーダー (1px)
- スケールアニメーション
- レタースペーシング調整 (-0.01em)

## 統一されたスタイル
- padding: 10px 18px
- border-radius: 10px
- transition: cubic-bezier(0.4, 0, 0.2, 1)
- active時の影: rgba(0, 122, 255, 0.25)

## 確認事項
- ✅ ダッシュボード、単元管理、テスト成績で学年ボタンのスタイルが統一
- ✅ 見た目の一貫性が向上