### PR TITLE
Integrate PDF upload into past paper management, remove PDF tab

### DIFF
--- a/child-learning-app/src/App.jsx
+++ b/child-learning-app/src/App.jsx
@@ -13,7 +13,6 @@ import PastPaperView from './components/PastPaperView'
 import TestScoreView from './components/TestScoreView'
 import TargetSchoolView from './components/TargetSchoolView'
 import StudyTimer from './components/StudyTimer'
-import PDFProblemView from './components/PDFProblemView'
 import { generateSAPIXScheduleByGrade } from './utils/sampleData'
 import {
   addTaskToFirestore,
@@ -36,7 +35,7 @@ import { toast } from './utils/toast'
 function App() {
   const [user, setUser] = useState(null)
   const [tasks, setTasks] = useState([])
-  const [view, setView] = useState('calendar') // subject, calendar, analytics, tasks, edit, unitManager, pastpaper, testscore, targetschool, timer, pdfproblem
+  const [view, setView] = useState('calendar') // subject, calendar, analytics, tasks, edit, unitManager, pastpaper, testscore, targetschool, timer
   const [previousView, setPreviousView] = useState('calendar') // Store previous view for returning after edit
   const [editingTask, setEditingTask] = useState(null)
   const [targetSchools, setTargetSchools] = useState([])
@@ -410,12 +409,6 @@ function App() {
           >
             ⏱️ タイマー
           </button>
-          <button
-            className={view === 'pdfproblem' ? 'active' : ''}
-            onClick={() => setView('pdfproblem')}
-          >
-            📕 PDF問題集
-          </button>
         </div>
 
         {view === 'subject' ? (
@@ -467,16 +460,12 @@ function App() {
           />
         ) : view === 'timer' ? (
           <StudyTimer />
-        ) : view === 'pdfproblem' ? (
-          <PDFProblemView
-            user={user}
-          />
         ) : null}
           </>
         )}
 
         {/* 3. タスク追加フォーム（一番下） - only show when not in edit view, unitManager view, pastpaper view, or testscore view */}
-        {view !== 'edit' && view !== 'unitManager' && view !== 'pastpaper' && view !== 'testscore' && view !== 'targetschool' && view !== 'timer' && view !== 'pdfproblem' && (
+        {view !== 'edit' && view !== 'unitManager' && view !== 'pastpaper' && view !== 'testscore' && view !== 'targetschool' && view !== 'timer' && (
           <div ref={taskFormRef}>
             <TaskForm
               onAddTask={addTask}

--- a/child-learning-app/src/components/PastPaperView.css
+++ b/child-learning-app/src/components/PastPaperView.css
@@ -130,16 +130,52 @@
   margin-bottom: 12px;
 }
 
-/* 問題ファイルURL入力 */
+/* 問題ファイルアップロード＋URL入力 */
+.file-upload-area {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+
+.pdf-upload-btn {
+  flex-shrink: 0;
+  padding: 10px 16px;
+  background: #4285f4;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s;
+  white-space: nowrap;
+}
+
+.pdf-upload-btn:hover {
+  background: #3367d6;
+}
+
+.pdf-upload-btn:disabled {
+  background: #93c5fd;
+  cursor: not-allowed;
+}
+
+.file-or-divider {
+  color: #94a3b8;
+  font-size: 0.85rem;
+  flex-shrink: 0;
+}
+
 .file-url-input {
-  width: 100%;
+  flex: 1;
+  min-width: 0;
   padding: 10px 12px;
   border: 2px solid #e2e8f0;
   border-radius: 8px;
   font-size: 0.9rem;
   box-sizing: border-box;
   transition: all 0.3s ease;
-  margin-bottom: 8px;
 }
 
 .file-url-input:focus {
@@ -148,11 +184,60 @@
   box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
 }
 
+.file-url-preview {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: #eff6ff;
+  border-radius: 8px;
+  margin-bottom: 8px;
+}
+
+.file-url-preview a {
+  flex: 1;
+  color: #2563eb;
+  font-size: 0.85rem;
+  text-decoration: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-url-preview a:hover {
+  text-decoration: underline;
+}
+
+.clear-url-btn {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: #94a3b8;
+  font-size: 1.2rem;
+  cursor: pointer;
+  padding: 0 4px;
+  line-height: 1;
+}
+
+.clear-url-btn:hover {
+  color: #ef4444;
+}
+
 .input-hint {
   display: block;
   color: #64748b;
   font-size: 0.8rem;
   font-style: italic;
+}
+
+@media (max-width: 600px) {
+  .file-upload-area {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .file-or-divider {
+    text-align: center;
+  }
 }
 
 /* 科目選択（フォーム内） */


### PR DESCRIPTION
過去問管理にGoogle DriveへのPDFアップロード機能を統合し、
重複していたPDF問題集タブを廃止。
- 過去問追加/編集フォームにPDFアップロードボタンを追加
- URL手入力とアップロードの両方に対応
- アップロード済みファイルのプレビュー・削除UI
- モバイル対応レイアウト

https://claude.ai/code/session_01DB58BeoxU9mNtK9Y9h71qa