### PR TITLE
Consolidate 7 tabs into 4 tabs for better UX

### DIFF
--- a/child-learning-app/src/App.jsx
+++ b/child-learning-app/src/App.jsx
@@ -4,11 +4,8 @@ import './utils/toast.css'
 import Auth from './components/Auth'
 import TodayAndWeekView from './components/TodayAndWeekView'
 import TaskForm from './components/TaskForm'
-import TaskList from './components/TaskList'
-import WeeklyCalendar from './components/WeeklyCalendar'
-import UnitDashboard from './components/UnitDashboard'
-import Analytics from './components/Analytics'
-import UnitManager from './components/UnitManager'
+import ScheduleView from './components/ScheduleView'
+import UnitAnalysisView from './components/UnitAnalysisView'
 import PastPaperView from './components/PastPaperView'
 import TestScoreView from './components/TestScoreView'
 import { generateSAPIXScheduleByGrade } from './utils/sampleData'
@@ -31,8 +28,8 @@ import { toast } from './utils/toast'
 function App() {
   const [user, setUser] = useState(null)
   const [tasks, setTasks] = useState([])
-  const [view, setView] = useState('calendar') // subject, calendar, analytics, tasks, edit, unitManager, pastpaper, testscore
-  const [previousView, setPreviousView] = useState('calendar') // Store previous view for returning after edit
+  const [view, setView] = useState('schedule') // schedule, unitAnalysis, pastpaper, testscore, edit
+  const [previousView, setPreviousView] = useState('schedule') // Store previous view for returning after edit
   const [editingTask, setEditingTask] = useState(null)
   const [customUnits, setCustomUnits] = useState([]) // カスタム単元
   const taskFormRef = useRef(null)
@@ -330,34 +327,16 @@ function App() {
             {/* 2. ビュー切り替え */}
             <div className="view-switcher">
           <button
-            className={view === 'subject' ? 'active' : ''}
-            onClick={() => setView('subject')}
+            className={view === 'schedule' ? 'active' : ''}
+            onClick={() => setView('schedule')}
           >
-            📊 ダッシュボード
+            📅 スケジュール
           </button>
           <button
-            className={view === 'analytics' ? 'active' : ''}
-            onClick={() => setView('analytics')}
+            className={view === 'unitAnalysis' ? 'active' : ''}
+            onClick={() => setView('unitAnalysis')}
           >
-            📈 分析
-          </button>
-          <button
-            className={view === 'calendar' ? 'active' : ''}
-            onClick={() => setView('calendar')}
-          >
-            📅 カレンダー
-          </button>
-          <button
-            className={view === 'tasks' ? 'active' : ''}
-            onClick={() => setView('tasks')}
-          >
-            📋 タスク
-          </button>
-          <button
-            className={view === 'unitManager' ? 'active' : ''}
-            onClick={() => setView('unitManager')}
-          >
-            📚 単元管理
+            📊 単元分析
           </button>
           <button
             className={view === 'pastpaper' ? 'active' : ''}
@@ -369,35 +348,22 @@ function App() {
             className={view === 'testscore' ? 'active' : ''}
             onClick={() => setView('testscore')}
           >
-            📊 テスト成績
+            📈 テスト成績
           </button>
         </div>
 
-        {view === 'subject' ? (
-          <UnitDashboard
-            tasks={tasks}
-            onEditTask={handleEditTask}
-            customUnits={customUnits}
-          />
-        ) : view === 'analytics' ? (
-          <Analytics tasks={tasks} />
-        ) : view === 'calendar' ? (
-          <WeeklyCalendar
-            tasks={tasks}
-            onToggleTask={toggleTask}
-            onDeleteTask={deleteTask}
-            onEditTask={handleEditTask}
-          />
-        ) : view === 'tasks' ? (
-          <TaskList
+        {view === 'schedule' ? (
+          <ScheduleView
             tasks={tasks}
             onToggleTask={toggleTask}
             onDeleteTask={deleteTask}
             onBulkDeleteTasks={bulkDeleteTasks}
             onEditTask={handleEditTask}
           />
-        ) : view === 'unitManager' ? (
-          <UnitManager
+        ) : view === 'unitAnalysis' ? (
+          <UnitAnalysisView
+            tasks={tasks}
+            onEditTask={handleEditTask}
             customUnits={customUnits}
             onAddCustomUnit={addCustomUnit}
             onUpdateUnit={updateCustomUnit}
@@ -420,8 +386,8 @@ function App() {
           </>
         )}
 
-        {/* 3. タスク追加フォーム（一番下） - only show when not in edit view, unitManager view, pastpaper view, or testscore view */}
-        {view !== 'edit' && view !== 'unitManager' && view !== 'pastpaper' && view !== 'testscore' && (
+        {/* 3. タスク追加フォーム（一番下） - show only on schedule view */}
+        {view === 'schedule' && (
           <div ref={taskFormRef}>
             <TaskForm
               onAddTask={addTask}

--- a/child-learning-app/src/components/ScheduleView.css
+++ b/child-learning-app/src/components/ScheduleView.css
@@ -1,0 +1,47 @@
+.schedule-view {
+  width: 100%;
+}
+
+.sub-tab-switcher {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 20px;
+  padding: 3px;
+  background: #f5f5f7;
+  border-radius: 10px;
+  width: fit-content;
+}
+
+.sub-tab-switcher button {
+  padding: 8px 20px;
+  border: none;
+  background: transparent;
+  color: #86868b;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.875rem;
+  font-weight: 500;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.sub-tab-switcher button:hover {
+  color: #1d1d1f;
+}
+
+.sub-tab-switcher button.active {
+  background: white;
+  color: #007AFF;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+}
+
+@media (max-width: 480px) {
+  .sub-tab-switcher {
+    width: 100%;
+  }
+
+  .sub-tab-switcher button {
+    flex: 1;
+    padding: 8px 12px;
+    font-size: 0.8125rem;
+  }
+}

--- a/child-learning-app/src/components/ScheduleView.jsx
+++ b/child-learning-app/src/components/ScheduleView.jsx
@@ -1,0 +1,46 @@
+import { useState } from 'react'
+import './ScheduleView.css'
+import WeeklyCalendar from './WeeklyCalendar'
+import TaskList from './TaskList'
+
+function ScheduleView({ tasks, onToggleTask, onDeleteTask, onBulkDeleteTasks, onEditTask }) {
+  const [subView, setSubView] = useState('calendar') // 'calendar' or 'tasks'
+
+  return (
+    <div className="schedule-view">
+      <div className="sub-tab-switcher">
+        <button
+          className={subView === 'calendar' ? 'active' : ''}
+          onClick={() => setSubView('calendar')}
+        >
+          カレンダー
+        </button>
+        <button
+          className={subView === 'tasks' ? 'active' : ''}
+          onClick={() => setSubView('tasks')}
+        >
+          タスク一覧
+        </button>
+      </div>
+
+      {subView === 'calendar' ? (
+        <WeeklyCalendar
+          tasks={tasks}
+          onToggleTask={onToggleTask}
+          onDeleteTask={onDeleteTask}
+          onEditTask={onEditTask}
+        />
+      ) : (
+        <TaskList
+          tasks={tasks}
+          onToggleTask={onToggleTask}
+          onDeleteTask={onDeleteTask}
+          onBulkDeleteTasks={onBulkDeleteTasks}
+          onEditTask={onEditTask}
+        />
+      )}
+    </div>
+  )
+}
+
+export default ScheduleView

--- a/child-learning-app/src/components/UnitAnalysisView.jsx
+++ b/child-learning-app/src/components/UnitAnalysisView.jsx
@@ -1,0 +1,53 @@
+import { useState } from 'react'
+import '../components/ScheduleView.css'
+import UnitDashboard from './UnitDashboard'
+import Analytics from './Analytics'
+import UnitManager from './UnitManager'
+
+function UnitAnalysisView({ tasks, onEditTask, customUnits, onAddCustomUnit, onUpdateUnit, onDeleteUnit }) {
+  const [subView, setSubView] = useState('dashboard') // 'dashboard', 'analytics', 'unitManager'
+
+  return (
+    <div className="unit-analysis-view">
+      <div className="sub-tab-switcher">
+        <button
+          className={subView === 'dashboard' ? 'active' : ''}
+          onClick={() => setSubView('dashboard')}
+        >
+          単元ダッシュボード
+        </button>
+        <button
+          className={subView === 'analytics' ? 'active' : ''}
+          onClick={() => setSubView('analytics')}
+        >
+          学習分析
+        </button>
+        <button
+          className={subView === 'unitManager' ? 'active' : ''}
+          onClick={() => setSubView('unitManager')}
+        >
+          カスタム単元
+        </button>
+      </div>
+
+      {subView === 'dashboard' ? (
+        <UnitDashboard
+          tasks={tasks}
+          onEditTask={onEditTask}
+          customUnits={customUnits}
+        />
+      ) : subView === 'analytics' ? (
+        <Analytics tasks={tasks} />
+      ) : (
+        <UnitManager
+          customUnits={customUnits}
+          onAddCustomUnit={onAddCustomUnit}
+          onUpdateUnit={onUpdateUnit}
+          onDeleteUnit={onDeleteUnit}
+        />
+      )}
+    </div>
+  )
+}
+
+export default UnitAnalysisView


### PR DESCRIPTION
Changed navigation from:
- ダッシュボード
- 分析
- カレンダー
- タスク
- 単元管理
- 過去問
- テスト成績

To:
- スケジュール (Calendar + Tasks with sub-tabs)
- 単元分析 (Dashboard + Analytics + Unit Manager with sub-tabs)
- 過去問 (unchanged)
- テスト成績 (unchanged)

This reduces cognitive load and groups related functionality together.

https://claude.ai/code/session_01DB58BeoxU9mNtK9Y9h71qa