### PR TITLE
Restructure app: Dashboard tab + master unit system overhaul

### DIFF
--- a/child-learning-app/src/App.jsx
+++ b/child-learning-app/src/App.jsx
@@ -8,7 +8,6 @@ import ScheduleView from './components/ScheduleView'
 import UnitAnalysisView from './components/UnitAnalysisView'
 import PastPaperView from './components/PastPaperView'
 import TestScoreView from './components/TestScoreView'
-import PDFProblemView from './components/PDFProblemView'
 import SapixTextView from './components/SapixTextView'
 import { generateSAPIXScheduleByGrade } from './utils/sampleData'
 import {
@@ -30,7 +29,7 @@ import { toast } from './utils/toast'
 function App() {
   const [user, setUser] = useState(null)
   const [tasks, setTasks] = useState([])
-  const [view, setView] = useState('schedule') // schedule, unitAnalysis, pastpaper, testscore, pdfproblem, sapixtext, edit
+  const [view, setView] = useState('schedule') // schedule, dashboard, pastpaper, testscore, sapixtext, edit
   const [previousView, setPreviousView] = useState('schedule') // Store previous view for returning after edit
   const [editingTask, setEditingTask] = useState(null)
   const [customUnits, setCustomUnits] = useState([]) // カスタム単元
@@ -335,10 +334,10 @@ function App() {
             📅 スケジュール
           </button>
           <button
-            className={view === 'unitAnalysis' ? 'active' : ''}
-            onClick={() => setView('unitAnalysis')}
+            className={view === 'sapixtext' ? 'active' : ''}
+            onClick={() => setView('sapixtext')}
           >
-            📊 単元分析
+            📘 サピックス課題
           </button>
           <button
             className={view === 'pastpaper' ? 'active' : ''}
@@ -353,16 +352,10 @@ function App() {
             📈 テスト成績
           </button>
           <button
-            className={view === 'pdfproblem' ? 'active' : ''}
-            onClick={() => setView('pdfproblem')}
+            className={view === 'dashboard' ? 'active' : ''}
+            onClick={() => setView('dashboard')}
           >
-            📝 PDF問題管理
-          </button>
-          <button
-            className={view === 'sapixtext' ? 'active' : ''}
-            onClick={() => setView('sapixtext')}
-          >
-            📘 SAPIX
+            🏠 ダッシュボード
           </button>
         </div>
 
@@ -374,14 +367,9 @@ function App() {
             onBulkDeleteTasks={bulkDeleteTasks}
             onEditTask={handleEditTask}
           />
-        ) : view === 'unitAnalysis' ? (
+        ) : view === 'dashboard' ? (
           <UnitAnalysisView
             tasks={tasks}
-            onEditTask={handleEditTask}
-            customUnits={customUnits}
-            onAddCustomUnit={addCustomUnit}
-            onUpdateUnit={updateCustomUnit}
-            onDeleteUnit={deleteCustomUnit}
           />
         ) : view === 'pastpaper' ? (
           <PastPaperView
@@ -394,10 +382,6 @@ function App() {
           />
         ) : view === 'testscore' ? (
           <TestScoreView
-            user={user}
-          />
-        ) : view === 'pdfproblem' ? (
-          <PDFProblemView
             user={user}
           />
         ) : view === 'sapixtext' ? (

--- a/child-learning-app/src/components/MasterUnitDashboard.css
+++ b/child-learning-app/src/components/MasterUnitDashboard.css
@@ -1,0 +1,345 @@
+.master-unit-dashboard {
+  padding: 16px;
+}
+
+.mud-loading {
+  text-align: center;
+  padding: 60px;
+  color: #6b7280;
+  font-size: 16px;
+}
+
+/* サマリー */
+.mud-summary {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  padding: 16px 20px;
+  background: #f8fafc;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.mud-summary-card {
+  text-align: center;
+  min-width: 80px;
+}
+
+.mud-summary-value {
+  font-size: 28px;
+  font-weight: 700;
+  color: #1f2937;
+  line-height: 1;
+}
+
+.mud-summary-total {
+  font-size: 16px;
+  color: #9ca3af;
+}
+
+.mud-summary-label {
+  font-size: 11px;
+  color: #6b7280;
+  margin-top: 4px;
+}
+
+.mud-level-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  flex: 1;
+}
+
+.mud-level-item {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 12px;
+  color: #374151;
+}
+
+.mud-level-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+/* カテゴリフィルター */
+.mud-category-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 20px;
+}
+
+.mud-cat-btn {
+  padding: 5px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 20px;
+  background: white;
+  font-size: 13px;
+  cursor: pointer;
+  color: #374151;
+  transition: all 0.15s;
+}
+
+.mud-cat-btn:hover {
+  border-color: #3b82f6;
+  color: #3b82f6;
+}
+
+.mud-cat-btn.active {
+  background: #3b82f6;
+  border-color: #3b82f6;
+  color: white;
+}
+
+/* カテゴリセクション */
+.mud-categories {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.mud-category-section {
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  padding: 16px;
+}
+
+.mud-cat-title {
+  font-size: 15px;
+  font-weight: 700;
+  color: #1f2937;
+  margin: 0 0 12px;
+  padding-bottom: 8px;
+  border-bottom: 2px solid #f3f4f6;
+}
+
+/* 単元グリッド */
+.mud-unit-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+  gap: 8px;
+}
+
+.mud-unit-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 10px 6px;
+  border: 2px solid var(--prof-color, #d1d5db);
+  border-radius: 8px;
+  background: white;
+  cursor: pointer;
+  transition: all 0.2s;
+  text-align: center;
+  position: relative;
+}
+
+.mud-unit-cell:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+}
+
+.mud-unit-indicator {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  position: absolute;
+  top: 6px;
+  right: 6px;
+}
+
+.mud-unit-name {
+  font-size: 12px;
+  font-weight: 600;
+  color: #1f2937;
+  line-height: 1.3;
+}
+
+.mud-unit-score {
+  font-size: 18px;
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.mud-unit-level {
+  font-size: 10px;
+  font-weight: 600;
+}
+
+/* モーダル */
+.mud-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 20px;
+}
+
+.mud-modal {
+  background: white;
+  border-radius: 12px;
+  padding: 24px;
+  width: 100%;
+  max-width: 400px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+}
+
+.mud-modal h3 {
+  margin: 0 0 6px;
+  font-size: 18px;
+}
+
+.mud-modal-unit {
+  font-size: 20px;
+  font-weight: 700;
+  color: #1d4ed8;
+  margin: 0 0 4px;
+}
+
+.mud-modal-cat {
+  font-size: 13px;
+  color: #6b7280;
+  margin: 0 0 20px;
+}
+
+.mud-form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.mud-form-group label {
+  display: block;
+  font-size: 13px;
+  font-weight: 600;
+  color: #374151;
+  margin-bottom: 6px;
+}
+
+.mud-result-btns {
+  display: flex;
+  gap: 10px;
+}
+
+.mud-result-btn {
+  flex: 1;
+  padding: 10px;
+  border: 2px solid #e5e7eb;
+  border-radius: 8px;
+  background: white;
+  font-size: 15px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.mud-result-btn.correct.selected {
+  background: #dcfce7;
+  border-color: #16a34a;
+  color: #15803d;
+}
+
+.mud-result-btn.incorrect.selected {
+  background: #fee2e2;
+  border-color: #dc2626;
+  color: #b91c1c;
+}
+
+.mud-result-btn:hover:not(.selected) {
+  border-color: #9ca3af;
+}
+
+.mud-input {
+  width: 100%;
+  padding: 9px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  font-size: 14px;
+  box-sizing: border-box;
+}
+
+.mud-input:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.mud-textarea {
+  width: 100%;
+  padding: 9px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  font-size: 13px;
+  resize: vertical;
+  box-sizing: border-box;
+  font-family: inherit;
+}
+
+.mud-textarea:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.mud-modal-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.mud-btn-cancel {
+  flex: 1;
+  padding: 11px;
+  background: white;
+  color: #6b7280;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.mud-btn-cancel:hover:not(:disabled) {
+  background: #f3f4f6;
+}
+
+.mud-btn-save {
+  flex: 2;
+  padding: 11px;
+  background: #3b82f6;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.mud-btn-save:hover:not(:disabled) {
+  background: #2563eb;
+}
+
+.mud-btn-save:disabled,
+.mud-btn-cancel:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+@media (max-width: 768px) {
+  .mud-unit-grid {
+    grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+  }
+
+  .mud-summary {
+    gap: 12px;
+  }
+}

--- a/child-learning-app/src/components/MasterUnitDashboard.jsx
+++ b/child-learning-app/src/components/MasterUnitDashboard.jsx
@@ -1,0 +1,256 @@
+import { useState, useEffect } from 'react'
+import { getAuth } from 'firebase/auth'
+import { getAllMasterUnits } from '../utils/weaknessAnalysisApi'
+import { getLessonLogs, computeAllProficiencies, getProficiencyLevel, addLessonLog } from '../utils/lessonLogs'
+import './MasterUnitDashboard.css'
+
+const CATEGORY_ORDER = ['計算', '数の性質', '規則性', '特殊算', '速さ', '割合', '比', '平面図形', '立体図形', '場合の数', 'グラフ・論理']
+
+function MasterUnitDashboard() {
+  const [loading, setLoading] = useState(true)
+  const [masterUnits, setMasterUnits] = useState([])
+  const [proficiencies, setProficiencies] = useState({})
+  const [selectedCategory, setSelectedCategory] = useState('all')
+  const [practiceModal, setPracticeModal] = useState(null)
+  const [practiceForm, setPracticeForm] = useState({ performance: '', isCorrect: null, notes: '' })
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    loadData()
+  }, [])
+
+  const loadData = async () => {
+    setLoading(true)
+    try {
+      const auth = getAuth()
+      const userId = auth.currentUser?.uid
+      if (!userId) return
+
+      const [units, logsResult] = await Promise.all([
+        getAllMasterUnits(),
+        getLessonLogs(userId)
+      ])
+
+      setMasterUnits(units)
+
+      if (logsResult.success) {
+        setProficiencies(computeAllProficiencies(logsResult.data))
+      }
+    } catch (err) {
+      console.error('データ取得エラー:', err)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleOpenPractice = (unit) => {
+    setPracticeModal(unit)
+    setPracticeForm({ performance: '', isCorrect: null, notes: '' })
+  }
+
+  const handleSavePractice = async () => {
+    if (practiceForm.isCorrect === null && practiceForm.performance === '') {
+      alert('結果を入力してください')
+      return
+    }
+
+    const auth = getAuth()
+    const userId = auth.currentUser?.uid
+    if (!userId) return
+
+    setSaving(true)
+    try {
+      const performance = practiceForm.performance !== ''
+        ? parseInt(practiceForm.performance)
+        : practiceForm.isCorrect ? 100 : 0
+
+      await addLessonLog(userId, {
+        unitIds: [practiceModal.id],
+        sourceType: 'practice',
+        sourceName: practiceModal.name,
+        date: new Date(),
+        performance,
+        isCorrect: practiceForm.isCorrect,
+        notes: practiceForm.notes,
+      })
+
+      setPracticeModal(null)
+      await loadData()
+    } catch (err) {
+      console.error('練習記録エラー:', err)
+      alert('記録に失敗しました')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const categories = ['all', ...CATEGORY_ORDER]
+
+  const filteredUnits = selectedCategory === 'all'
+    ? masterUnits
+    : masterUnits.filter(u => u.category === selectedCategory)
+
+  // カテゴリ順でグループ化
+  const groupedUnits = CATEGORY_ORDER.reduce((acc, cat) => {
+    const units = filteredUnits.filter(u => u.category === cat)
+    if (units.length > 0) acc[cat] = units
+    return acc
+  }, {})
+
+  // 全体統計
+  const totalUnits = masterUnits.length
+  const studiedUnits = Object.keys(proficiencies).length
+  const avgScore = studiedUnits > 0
+    ? Math.round(
+        Object.values(proficiencies).reduce((s, p) => s + Math.max(0, p.score), 0) / studiedUnits
+      )
+    : 0
+
+  const levelCounts = [0, 1, 2, 3, 4, 5].map(lv =>
+    Object.values(proficiencies).filter(p => p.level === lv).length
+  )
+
+  if (loading) {
+    return <div className="mud-loading">📊 単元データを読み込み中...</div>
+  }
+
+  return (
+    <div className="master-unit-dashboard">
+      {/* 全体サマリー */}
+      <div className="mud-summary">
+        <div className="mud-summary-card">
+          <div className="mud-summary-value">{studiedUnits}<span className="mud-summary-total">/{totalUnits}</span></div>
+          <div className="mud-summary-label">学習済み単元</div>
+        </div>
+        <div className="mud-summary-card">
+          <div className="mud-summary-value">{avgScore}</div>
+          <div className="mud-summary-label">平均習熟度</div>
+        </div>
+        <div className="mud-level-bar">
+          {[
+            { lv: 5, label: '得意', color: '#16a34a' },
+            { lv: 4, label: '良好', color: '#2563eb' },
+            { lv: 3, label: '普通', color: '#ca8a04' },
+            { lv: 2, label: '要復習', color: '#ea580c' },
+            { lv: 1, label: '苦手', color: '#dc2626' },
+          ].map(({ lv, label, color }) => (
+            <div key={lv} className="mud-level-item">
+              <div className="mud-level-dot" style={{ background: color }} />
+              <span>{label}: {levelCounts[lv]}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* カテゴリフィルター */}
+      <div className="mud-category-filter">
+        {categories.map(cat => (
+          <button
+            key={cat}
+            className={`mud-cat-btn ${selectedCategory === cat ? 'active' : ''}`}
+            onClick={() => setSelectedCategory(cat)}
+          >
+            {cat === 'all' ? '全て' : cat}
+          </button>
+        ))}
+      </div>
+
+      {/* 単元グリッド（カテゴリ別） */}
+      <div className="mud-categories">
+        {Object.entries(groupedUnits).map(([cat, units]) => (
+          <div key={cat} className="mud-category-section">
+            <h3 className="mud-cat-title">{cat}</h3>
+            <div className="mud-unit-grid">
+              {units.map(unit => {
+                const prof = proficiencies[unit.id]
+                const level = prof ? getProficiencyLevel(prof.score) : getProficiencyLevel(-1)
+                return (
+                  <button
+                    key={unit.id}
+                    className="mud-unit-cell"
+                    style={{ '--prof-color': level.color }}
+                    onClick={() => handleOpenPractice(unit)}
+                    title={`${unit.name}\n難易度: ${'★'.repeat(unit.difficultyLevel || 1)}\n${prof ? `習熟度: ${prof.score}点 (${level.label})` : '未学習'}`}
+                  >
+                    <div className="mud-unit-indicator" style={{ background: level.color }} />
+                    <div className="mud-unit-name">{unit.name}</div>
+                    {prof && (
+                      <div className="mud-unit-score">{prof.score}点</div>
+                    )}
+                    <div className="mud-unit-level" style={{ color: level.color }}>{level.label}</div>
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* 練習記録モーダル */}
+      {practiceModal && (
+        <div className="mud-modal-overlay" onClick={() => setPracticeModal(null)}>
+          <div className="mud-modal" onClick={e => e.stopPropagation()}>
+            <h3>✏️ 練習を記録</h3>
+            <p className="mud-modal-unit">{practiceModal.name}</p>
+            <p className="mud-modal-cat">{practiceModal.category} / 難易度 {'★'.repeat(practiceModal.difficultyLevel || 1)}</p>
+
+            <div className="mud-form">
+              <div className="mud-form-group">
+                <label>結果</label>
+                <div className="mud-result-btns">
+                  <button
+                    className={`mud-result-btn correct ${practiceForm.isCorrect === true ? 'selected' : ''}`}
+                    onClick={() => setPracticeForm(f => ({ ...f, isCorrect: true, performance: '' }))}
+                  >⭕ 正解</button>
+                  <button
+                    className={`mud-result-btn incorrect ${practiceForm.isCorrect === false ? 'selected' : ''}`}
+                    onClick={() => setPracticeForm(f => ({ ...f, isCorrect: false, performance: '' }))}
+                  >❌ 不正解</button>
+                </div>
+              </div>
+
+              <div className="mud-form-group">
+                <label>得点率 (0-100、任意)</label>
+                <input
+                  type="number"
+                  min="0"
+                  max="100"
+                  placeholder="例: 75"
+                  value={practiceForm.performance}
+                  onChange={e => setPracticeForm(f => ({ ...f, performance: e.target.value, isCorrect: null }))}
+                  className="mud-input"
+                />
+              </div>
+
+              <div className="mud-form-group">
+                <label>メモ</label>
+                <textarea
+                  placeholder="気づいたことや次回へのコメント..."
+                  value={practiceForm.notes}
+                  onChange={e => setPracticeForm(f => ({ ...f, notes: e.target.value }))}
+                  className="mud-textarea"
+                  rows={2}
+                />
+              </div>
+            </div>
+
+            <div className="mud-modal-actions">
+              <button className="mud-btn-cancel" onClick={() => setPracticeModal(null)} disabled={saving}>
+                キャンセル
+              </button>
+              <button
+                className="mud-btn-save"
+                onClick={handleSavePractice}
+                disabled={saving || (practiceForm.isCorrect === null && practiceForm.performance === '')}
+              >
+                {saving ? '記録中...' : '記録する'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default MasterUnitDashboard

--- a/child-learning-app/src/components/MasterUnitEditor.css
+++ b/child-learning-app/src/components/MasterUnitEditor.css
@@ -1,0 +1,343 @@
+.master-unit-editor {
+  padding: 16px;
+}
+
+.mue-loading {
+  text-align: center;
+  padding: 60px;
+  color: #6b7280;
+}
+
+/* ヘッダー */
+.mue-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 14px;
+}
+
+.mue-stats {
+  font-size: 14px;
+  color: #6b7280;
+}
+
+.mue-add-btn {
+  padding: 9px 18px;
+  background: #3b82f6;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.mue-add-btn:hover {
+  background: #2563eb;
+}
+
+/* フィルター */
+.mue-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 16px;
+}
+
+.mue-cat-btn {
+  padding: 4px 10px;
+  border: 1px solid #d1d5db;
+  border-radius: 16px;
+  background: white;
+  font-size: 12px;
+  cursor: pointer;
+  color: #374151;
+}
+
+.mue-cat-btn:hover {
+  border-color: #3b82f6;
+  color: #3b82f6;
+}
+
+.mue-cat-btn.active {
+  background: #3b82f6;
+  border-color: #3b82f6;
+  color: white;
+}
+
+/* 単元リスト */
+.mue-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.mue-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px 14px;
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  transition: box-shadow 0.15s;
+}
+
+.mue-item:hover {
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+}
+
+.mue-item.inactive {
+  opacity: 0.5;
+  background: #f9fafb;
+}
+
+.mue-item-main {
+  flex: 1;
+}
+
+.mue-item-info {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.mue-item-name {
+  font-size: 15px;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.mue-item-id {
+  font-size: 11px;
+  font-family: monospace;
+  background: #f3f4f6;
+  color: #6b7280;
+  padding: 1px 6px;
+  border-radius: 4px;
+}
+
+.mue-item-cat {
+  font-size: 12px;
+  color: #3b82f6;
+  background: #eff6ff;
+  padding: 1px 8px;
+  border-radius: 10px;
+}
+
+.mue-item-diff {
+  font-size: 12px;
+  color: #f59e0b;
+}
+
+.mue-item-desc {
+  font-size: 12px;
+  color: #9ca3af;
+}
+
+.mue-item-actions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.mue-toggle-btn,
+.mue-edit-btn,
+.mue-delete-btn {
+  padding: 4px 10px;
+  border-radius: 5px;
+  font-size: 12px;
+  cursor: pointer;
+  border: 1px solid;
+}
+
+.mue-toggle-btn.on {
+  background: #dcfce7;
+  color: #15803d;
+  border-color: #86efac;
+}
+
+.mue-toggle-btn.off {
+  background: #f3f4f6;
+  color: #6b7280;
+  border-color: #d1d5db;
+}
+
+.mue-edit-btn {
+  background: #eff6ff;
+  color: #1d4ed8;
+  border-color: #bfdbfe;
+}
+
+.mue-edit-btn:hover {
+  background: #dbeafe;
+}
+
+.mue-delete-btn {
+  background: #fef2f2;
+  color: #dc2626;
+  border-color: #fecaca;
+}
+
+.mue-delete-btn:hover {
+  background: #fee2e2;
+}
+
+.mue-empty {
+  padding: 40px;
+  text-align: center;
+  color: #9ca3af;
+  font-size: 14px;
+}
+
+/* モーダル */
+.mue-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 20px;
+}
+
+.mue-modal {
+  background: white;
+  border-radius: 12px;
+  padding: 24px;
+  width: 100%;
+  max-width: 480px;
+  box-shadow: 0 20px 60px rgba(0,0,0,0.3);
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.mue-modal h3 {
+  margin: 0 0 20px;
+  font-size: 18px;
+}
+
+.mue-form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.mue-form-row label {
+  display: block;
+  font-size: 13px;
+  font-weight: 600;
+  color: #374151;
+  margin-bottom: 6px;
+}
+
+.required {
+  color: #dc2626;
+}
+
+.mue-input,
+.mue-select,
+.mue-textarea {
+  width: 100%;
+  padding: 9px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  font-size: 14px;
+  box-sizing: border-box;
+  font-family: inherit;
+}
+
+.mue-input:focus,
+.mue-select:focus,
+.mue-textarea:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.mue-input:disabled {
+  background: #f3f4f6;
+  color: #9ca3af;
+}
+
+.mue-hint {
+  font-size: 11px;
+  color: #9ca3af;
+  margin: 4px 0 0;
+}
+
+.mue-difficulty {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.mue-diff-btn {
+  background: none;
+  border: none;
+  font-size: 20px;
+  cursor: pointer;
+  color: #d1d5db;
+  padding: 0;
+  line-height: 1;
+}
+
+.mue-diff-btn.active {
+  color: #f59e0b;
+}
+
+.mue-diff-label {
+  font-size: 12px;
+  color: #6b7280;
+  margin-left: 6px;
+}
+
+.mue-textarea {
+  resize: vertical;
+}
+
+.mue-modal-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.mue-btn-cancel {
+  flex: 1;
+  padding: 11px;
+  background: white;
+  color: #6b7280;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.mue-btn-cancel:hover:not(:disabled) {
+  background: #f3f4f6;
+}
+
+.mue-btn-save {
+  flex: 2;
+  padding: 11px;
+  background: #3b82f6;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.mue-btn-save:hover:not(:disabled) {
+  background: #2563eb;
+}
+
+.mue-btn-save:disabled,
+.mue-btn-cancel:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/child-learning-app/src/components/MasterUnitEditor.jsx
+++ b/child-learning-app/src/components/MasterUnitEditor.jsx
@@ -1,0 +1,324 @@
+import { useState, useEffect } from 'react'
+import {
+  collection,
+  doc,
+  getDocs,
+  addDoc,
+  setDoc,
+  updateDoc,
+  deleteDoc,
+  query,
+  orderBy,
+  serverTimestamp,
+} from 'firebase/firestore'
+import { db } from '../firebase'
+import './MasterUnitEditor.css'
+
+const CATEGORIES = ['計算', '数の性質', '規則性', '特殊算', '速さ', '割合', '比', '平面図形', '立体図形', '場合の数', 'グラフ・論理']
+
+const EMPTY_FORM = {
+  id: '',
+  name: '',
+  category: '計算',
+  difficultyLevel: 3,
+  description: '',
+  orderIndex: 0,
+  isActive: true,
+}
+
+function MasterUnitEditor() {
+  const [units, setUnits] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [selectedCategory, setSelectedCategory] = useState('all')
+  const [modal, setModal] = useState(null) // null | 'add' | 'edit'
+  const [form, setForm] = useState(EMPTY_FORM)
+  const [saving, setSaving] = useState(false)
+  const [editingDocId, setEditingDocId] = useState(null)
+
+  useEffect(() => {
+    loadUnits()
+  }, [])
+
+  const loadUnits = async () => {
+    setLoading(true)
+    try {
+      const q = query(collection(db, 'masterUnits'), orderBy('orderIndex'))
+      const snapshot = await getDocs(q)
+      setUnits(snapshot.docs.map(d => ({ docId: d.id, ...d.data() })))
+    } catch (err) {
+      console.error('マスター単元取得エラー:', err)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleOpenAdd = () => {
+    const maxOrder = units.reduce((m, u) => Math.max(m, u.orderIndex || 0), 0)
+    setForm({ ...EMPTY_FORM, orderIndex: maxOrder + 10 })
+    setEditingDocId(null)
+    setModal('add')
+  }
+
+  const handleOpenEdit = (unit) => {
+    setForm({
+      id: unit.id || '',
+      name: unit.name || '',
+      category: unit.category || '計算',
+      difficultyLevel: unit.difficultyLevel || 3,
+      description: unit.description || '',
+      orderIndex: unit.orderIndex || 0,
+      isActive: unit.isActive !== false,
+    })
+    setEditingDocId(unit.docId)
+    setModal('edit')
+  }
+
+  const handleSave = async () => {
+    if (!form.name.trim()) {
+      alert('単元名を入力してください')
+      return
+    }
+
+    setSaving(true)
+    try {
+      const data = {
+        id: form.id.trim() || null,
+        name: form.name.trim(),
+        category: form.category,
+        difficultyLevel: parseInt(form.difficultyLevel),
+        description: form.description.trim(),
+        orderIndex: parseInt(form.orderIndex) || 0,
+        isActive: form.isActive,
+        updatedAt: serverTimestamp(),
+      }
+
+      if (modal === 'add') {
+        // 新規追加: id が指定されていれば setDoc、なければ addDoc
+        if (data.id) {
+          const ref = doc(db, 'masterUnits', data.id)
+          await setDoc(ref, { ...data, createdAt: serverTimestamp() })
+        } else {
+          delete data.id
+          await addDoc(collection(db, 'masterUnits'), { ...data, createdAt: serverTimestamp() })
+        }
+      } else {
+        // 更新
+        const ref = doc(db, 'masterUnits', editingDocId)
+        await updateDoc(ref, data)
+      }
+
+      setModal(null)
+      await loadUnits()
+    } catch (err) {
+      console.error('保存エラー:', err)
+      alert('保存に失敗しました: ' + err.message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDelete = async (unit) => {
+    if (!confirm(`「${unit.name}」を削除しますか？\nこの操作は取り消せません。`)) return
+
+    try {
+      await deleteDoc(doc(db, 'masterUnits', unit.docId))
+      await loadUnits()
+    } catch (err) {
+      console.error('削除エラー:', err)
+      alert('削除に失敗しました')
+    }
+  }
+
+  const handleToggleActive = async (unit) => {
+    try {
+      await updateDoc(doc(db, 'masterUnits', unit.docId), {
+        isActive: !unit.isActive,
+        updatedAt: serverTimestamp(),
+      })
+      await loadUnits()
+    } catch (err) {
+      console.error('更新エラー:', err)
+    }
+  }
+
+  const filteredUnits = selectedCategory === 'all'
+    ? units
+    : units.filter(u => u.category === selectedCategory)
+
+  const categories = ['all', ...CATEGORIES]
+
+  if (loading) {
+    return <div className="mue-loading">マスター単元を読み込み中...</div>
+  }
+
+  return (
+    <div className="master-unit-editor">
+      <div className="mue-header">
+        <div className="mue-stats">
+          <span>{units.length} 単元 / {units.filter(u => u.isActive !== false).length} 有効</span>
+        </div>
+        <button className="mue-add-btn" onClick={handleOpenAdd}>
+          ＋ 単元を追加
+        </button>
+      </div>
+
+      {/* カテゴリフィルター */}
+      <div className="mue-filter">
+        {categories.map(cat => (
+          <button
+            key={cat}
+            className={`mue-cat-btn ${selectedCategory === cat ? 'active' : ''}`}
+            onClick={() => setSelectedCategory(cat)}
+          >
+            {cat === 'all' ? '全て' : cat}
+          </button>
+        ))}
+      </div>
+
+      {/* 単元リスト */}
+      <div className="mue-list">
+        {filteredUnits.map(unit => (
+          <div
+            key={unit.docId}
+            className={`mue-item ${unit.isActive === false ? 'inactive' : ''}`}
+          >
+            <div className="mue-item-main">
+              <div className="mue-item-info">
+                <span className="mue-item-name">{unit.name}</span>
+                {unit.id && (
+                  <span className="mue-item-id">{unit.id}</span>
+                )}
+                <span className="mue-item-cat">{unit.category}</span>
+                <span className="mue-item-diff">
+                  {'★'.repeat(unit.difficultyLevel || 1)}{'☆'.repeat(5 - (unit.difficultyLevel || 1))}
+                </span>
+              </div>
+              {unit.description && (
+                <div className="mue-item-desc">{unit.description}</div>
+              )}
+            </div>
+            <div className="mue-item-actions">
+              <button
+                className={`mue-toggle-btn ${unit.isActive === false ? 'off' : 'on'}`}
+                onClick={() => handleToggleActive(unit)}
+                title={unit.isActive === false ? '有効にする' : '無効にする'}
+              >
+                {unit.isActive === false ? '無効' : '有効'}
+              </button>
+              <button className="mue-edit-btn" onClick={() => handleOpenEdit(unit)}>
+                編集
+              </button>
+              <button className="mue-delete-btn" onClick={() => handleDelete(unit)}>
+                削除
+              </button>
+            </div>
+          </div>
+        ))}
+
+        {filteredUnits.length === 0 && (
+          <div className="mue-empty">
+            {units.length === 0
+              ? 'まだ単元がありません。「＋ 単元を追加」から追加してください。'
+              : 'このカテゴリの単元がありません。'}
+          </div>
+        )}
+      </div>
+
+      {/* 追加/編集モーダル */}
+      {modal && (
+        <div className="mue-modal-overlay" onClick={() => setModal(null)}>
+          <div className="mue-modal" onClick={e => e.stopPropagation()}>
+            <h3>{modal === 'add' ? '＋ 単元を追加' : '✏️ 単元を編集'}</h3>
+
+            <div className="mue-form">
+              <div className="mue-form-row">
+                <label>単元名 <span className="required">*</span></label>
+                <input
+                  className="mue-input"
+                  value={form.name}
+                  onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
+                  placeholder="例: 四則計算の基礎"
+                />
+              </div>
+
+              <div className="mue-form-row">
+                <label>単元ID（省略可）</label>
+                <input
+                  className="mue-input"
+                  value={form.id}
+                  onChange={e => setForm(f => ({ ...f, id: e.target.value.toUpperCase() }))}
+                  placeholder="例: CALC_BASIC"
+                  disabled={modal === 'edit'}
+                />
+                {modal === 'add' && (
+                  <p className="mue-hint">省略時は自動採番。英大文字・アンダースコア推奨</p>
+                )}
+              </div>
+
+              <div className="mue-form-row">
+                <label>カテゴリ <span className="required">*</span></label>
+                <select
+                  className="mue-select"
+                  value={form.category}
+                  onChange={e => setForm(f => ({ ...f, category: e.target.value }))}
+                >
+                  {CATEGORIES.map(cat => (
+                    <option key={cat} value={cat}>{cat}</option>
+                  ))}
+                </select>
+              </div>
+
+              <div className="mue-form-row">
+                <label>難易度</label>
+                <div className="mue-difficulty">
+                  {[1, 2, 3, 4, 5].map(lv => (
+                    <button
+                      key={lv}
+                      className={`mue-diff-btn ${form.difficultyLevel >= lv ? 'active' : ''}`}
+                      onClick={() => setForm(f => ({ ...f, difficultyLevel: lv }))}
+                    >★</button>
+                  ))}
+                  <span className="mue-diff-label">
+                    {['', '基礎', '標準', '応用', '発展', '難関'][form.difficultyLevel]}
+                  </span>
+                </div>
+              </div>
+
+              <div className="mue-form-row">
+                <label>説明</label>
+                <textarea
+                  className="mue-textarea"
+                  value={form.description}
+                  onChange={e => setForm(f => ({ ...f, description: e.target.value }))}
+                  placeholder="単元の説明（任意）"
+                  rows={2}
+                />
+              </div>
+
+              <div className="mue-form-row">
+                <label>表示順序</label>
+                <input
+                  type="number"
+                  className="mue-input"
+                  value={form.orderIndex}
+                  onChange={e => setForm(f => ({ ...f, orderIndex: e.target.value }))}
+                />
+              </div>
+            </div>
+
+            <div className="mue-modal-actions">
+              <button className="mue-btn-cancel" onClick={() => setModal(null)} disabled={saving}>
+                キャンセル
+              </button>
+              <button className="mue-btn-save" onClick={handleSave} disabled={saving || !form.name.trim()}>
+                {saving ? '保存中...' : '保存'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default MasterUnitEditor

--- a/child-learning-app/src/components/ScheduleView.css
+++ b/child-learning-app/src/components/ScheduleView.css
@@ -45,3 +45,9 @@
     font-size: 0.8125rem;
   }
 }
+
+.study-analysis .analysis-divider {
+  height: 1px;
+  background: #e5e7eb;
+  margin: 20px 0;
+}

--- a/child-learning-app/src/components/UnitAnalysisView.jsx
+++ b/child-learning-app/src/components/UnitAnalysisView.jsx
@@ -1,12 +1,12 @@
 import { useState } from 'react'
 import '../components/ScheduleView.css'
-import UnitDashboard from './UnitDashboard'
+import MasterUnitDashboard from './MasterUnitDashboard'
 import Analytics from './Analytics'
-import UnitManager from './UnitManager'
 import WeaknessAnalysis from './WeaknessAnalysis'
+import MasterUnitEditor from './MasterUnitEditor'
 
-function UnitAnalysisView({ tasks, onEditTask, customUnits, onAddCustomUnit, onUpdateUnit, onDeleteUnit }) {
-  const [subView, setSubView] = useState('dashboard') // 'dashboard', 'analytics', 'unitManager', 'weakness'
+function UnitAnalysisView({ tasks }) {
+  const [subView, setSubView] = useState('dashboard') // 'dashboard', 'analysis', 'editor'
 
   return (
     <div className="unit-analysis-view">
@@ -15,45 +15,32 @@ function UnitAnalysisView({ tasks, onEditTask, customUnits, onAddCustomUnit, onU
           className={subView === 'dashboard' ? 'active' : ''}
           onClick={() => setSubView('dashboard')}
         >
-          単元ダッシュボード
+          🏠 単元ダッシュボード
         </button>
         <button
-          className={subView === 'analytics' ? 'active' : ''}
-          onClick={() => setSubView('analytics')}
+          className={subView === 'analysis' ? 'active' : ''}
+          onClick={() => setSubView('analysis')}
         >
-          学習分析
+          📊 学習分析
         </button>
         <button
-          className={subView === 'weakness' ? 'active' : ''}
-          onClick={() => setSubView('weakness')}
+          className={subView === 'editor' ? 'active' : ''}
+          onClick={() => setSubView('editor')}
         >
-          🎯 弱点分析
-        </button>
-        <button
-          className={subView === 'unitManager' ? 'active' : ''}
-          onClick={() => setSubView('unitManager')}
-        >
-          カスタム単元
+          ✏️ 単元編集
         </button>
       </div>
 
       {subView === 'dashboard' ? (
-        <UnitDashboard
-          tasks={tasks}
-          onEditTask={onEditTask}
-          customUnits={customUnits}
-        />
-      ) : subView === 'analytics' ? (
-        <Analytics tasks={tasks} />
-      ) : subView === 'weakness' ? (
-        <WeaknessAnalysis />
+        <MasterUnitDashboard />
+      ) : subView === 'analysis' ? (
+        <div className="study-analysis">
+          <Analytics tasks={tasks} />
+          <div className="analysis-divider" />
+          <WeaknessAnalysis />
+        </div>
       ) : (
-        <UnitManager
-          customUnits={customUnits}
-          onAddCustomUnit={onAddCustomUnit}
-          onUpdateUnit={onUpdateUnit}
-          onDeleteUnit={onDeleteUnit}
-        />
+        <MasterUnitEditor />
       )}
     </div>
   )

--- a/child-learning-app/src/utils/lessonLogs.js
+++ b/child-learning-app/src/utils/lessonLogs.js
@@ -1,0 +1,233 @@
+/**
+ * lessonLogs - 学習履歴の統合管理
+ *
+ * sapixTask / pastPaper / practice のすべての学習記録を
+ * masterUnits と紐付けて管理するコレクション
+ */
+
+import {
+  collection,
+  doc,
+  addDoc,
+  getDocs,
+  updateDoc,
+  deleteDoc,
+  query,
+  where,
+  orderBy,
+  serverTimestamp,
+} from 'firebase/firestore'
+import { db } from '../firebase'
+
+/**
+ * @typedef {Object} LessonLog
+ * @property {string} id - ドキュメントID
+ * @property {string[]} unitIds - 関連するマスター単元IDのリスト
+ * @property {'sapixTask'|'pastPaper'|'practice'} sourceType - 学習の種類
+ * @property {string} [sourceId] - 参照元ドキュメントID
+ * @property {string} [sourceName] - 参照元の名称（表示用）
+ * @property {Date|Timestamp} date - 学習日
+ * @property {number} performance - 得点率 0-100
+ * @property {boolean} [isCorrect] - 正解/不正解（practice用）
+ * @property {number} [timeSpent] - 所要時間（秒）
+ * @property {string} [notes] - メモ
+ * @property {number} [grade] - 記録時の学年（4/5/6）
+ * @property {Timestamp} createdAt
+ */
+
+/**
+ * lessonLog を追加
+ * @param {string} userId
+ * @param {Object} data
+ * @returns {Promise<{success: boolean, data?: LessonLog, error?: string}>}
+ */
+export async function addLessonLog(userId, data) {
+  try {
+    const docData = {
+      unitIds: data.unitIds || [],
+      sourceType: data.sourceType || 'practice',
+      sourceId: data.sourceId || null,
+      sourceName: data.sourceName || '',
+      date: data.date || serverTimestamp(),
+      performance: data.performance ?? 0,
+      isCorrect: data.isCorrect ?? null,
+      timeSpent: data.timeSpent || null,
+      notes: data.notes || '',
+      grade: data.grade || null,
+      createdAt: serverTimestamp(),
+    }
+
+    const ref = await addDoc(
+      collection(db, 'users', userId, 'lessonLogs'),
+      docData
+    )
+
+    return { success: true, data: { id: ref.id, ...docData } }
+  } catch (error) {
+    console.error('lessonLog 追加エラー:', error)
+    return { success: false, error: error.message }
+  }
+}
+
+/**
+ * ユーザーの全 lessonLog を取得
+ * @param {string} userId
+ * @returns {Promise<{success: boolean, data?: LessonLog[], error?: string}>}
+ */
+export async function getLessonLogs(userId) {
+  try {
+    const q = query(
+      collection(db, 'users', userId, 'lessonLogs'),
+      orderBy('createdAt', 'desc')
+    )
+    const snapshot = await getDocs(q)
+    const data = snapshot.docs.map(d => ({ id: d.id, ...d.data() }))
+    return { success: true, data }
+  } catch (error) {
+    console.error('lessonLog 取得エラー:', error)
+    return { success: false, error: error.message }
+  }
+}
+
+/**
+ * 特定の単元に紐づく lessonLog を取得
+ * @param {string} userId
+ * @param {string} unitId
+ * @returns {Promise<{success: boolean, data?: LessonLog[], error?: string}>}
+ */
+export async function getLessonLogsByUnit(userId, unitId) {
+  try {
+    const q = query(
+      collection(db, 'users', userId, 'lessonLogs'),
+      where('unitIds', 'array-contains', unitId),
+      orderBy('createdAt', 'desc')
+    )
+    const snapshot = await getDocs(q)
+    const data = snapshot.docs.map(d => ({ id: d.id, ...d.data() }))
+    return { success: true, data }
+  } catch (error) {
+    console.error('lessonLog (単元別) 取得エラー:', error)
+    return { success: false, error: error.message }
+  }
+}
+
+/**
+ * lessonLog を更新
+ * @param {string} userId
+ * @param {string} logId
+ * @param {Object} updates
+ * @returns {Promise<{success: boolean, error?: string}>}
+ */
+export async function updateLessonLog(userId, logId, updates) {
+  try {
+    const ref = doc(db, 'users', userId, 'lessonLogs', logId)
+    await updateDoc(ref, { ...updates, updatedAt: serverTimestamp() })
+    return { success: true }
+  } catch (error) {
+    console.error('lessonLog 更新エラー:', error)
+    return { success: false, error: error.message }
+  }
+}
+
+/**
+ * lessonLog を削除
+ * @param {string} userId
+ * @param {string} logId
+ * @returns {Promise<{success: boolean, error?: string}>}
+ */
+export async function deleteLessonLog(userId, logId) {
+  try {
+    const ref = doc(db, 'users', userId, 'lessonLogs', logId)
+    await deleteDoc(ref)
+    return { success: true }
+  } catch (error) {
+    console.error('lessonLog 削除エラー:', error)
+    return { success: false, error: error.message }
+  }
+}
+
+// ========================================
+// 習熟度計算ロジック
+// ========================================
+
+const HALF_LIFE_DAYS = 90
+const LAMBDA = Math.LN2 / HALF_LIFE_DAYS
+
+/**
+ * 時間減衰係数を計算
+ * @param {Date|Timestamp} date - 学習日
+ * @returns {number} - 0.0〜1.0 の減衰係数
+ */
+function getDecayWeight(date) {
+  const studyDate = date?.toDate ? date.toDate() : new Date(date)
+  const daysSince = (Date.now() - studyDate.getTime()) / (1000 * 60 * 60 * 24)
+  return Math.exp(-LAMBDA * Math.max(0, daysSince))
+}
+
+/**
+ * 単元の習熟度スコアを計算（0〜100）
+ * @param {LessonLog[]} logs - 単元に紐づくログ
+ * @returns {number} - 習熟度スコア 0-100
+ */
+export function computeProficiencyScore(logs) {
+  if (logs.length === 0) return -1 // データなし
+
+  let weightedSum = 0
+  let totalWeight = 0
+
+  for (const log of logs) {
+    const weight = getDecayWeight(log.date || log.createdAt)
+    const perf = log.performance ?? (log.isCorrect === true ? 100 : log.isCorrect === false ? 0 : 50)
+
+    weightedSum += perf * weight
+    totalWeight += weight
+  }
+
+  if (totalWeight === 0) return -1
+  return Math.round(weightedSum / totalWeight)
+}
+
+/**
+ * 習熟度スコアから習熟度レベルを取得
+ * @param {number} score - 習熟度スコア (-1 〜 100)
+ * @returns {{ level: number, label: string, color: string }}
+ */
+export function getProficiencyLevel(score) {
+  if (score < 0) return { level: 0, label: '未学習', color: '#d1d5db' }
+  if (score >= 90) return { level: 5, label: '得意', color: '#16a34a' }
+  if (score >= 75) return { level: 4, label: '良好', color: '#2563eb' }
+  if (score >= 60) return { level: 3, label: '普通', color: '#ca8a04' }
+  if (score >= 40) return { level: 2, label: '要復習', color: '#ea580c' }
+  return { level: 1, label: '苦手', color: '#dc2626' }
+}
+
+/**
+ * 全マスター単元の習熟度マップを計算
+ * @param {LessonLog[]} allLogs - ユーザーの全 lessonLog
+ * @returns {Object} - { unitId: { score, level, label, color, logCount } }
+ */
+export function computeAllProficiencies(allLogs) {
+  // 単元IDごとにログをグループ化
+  const logsByUnit = {}
+  for (const log of allLogs) {
+    for (const unitId of (log.unitIds || [])) {
+      if (!logsByUnit[unitId]) logsByUnit[unitId] = []
+      logsByUnit[unitId].push(log)
+    }
+  }
+
+  // 各単元の習熟度を計算
+  const result = {}
+  for (const [unitId, logs] of Object.entries(logsByUnit)) {
+    const score = computeProficiencyScore(logs)
+    const profLevel = getProficiencyLevel(score)
+    result[unitId] = {
+      score,
+      ...profLevel,
+      logCount: logs.length,
+      lastStudied: logs[0]?.date || logs[0]?.createdAt || null,
+    }
+  }
+
+  return result
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -106,6 +106,11 @@ service cloud.firestore {
       match /sapixTexts/{textId} {
         allow read, write: if isAuthenticated() && isOwner(userId);
       }
+
+      // 学習履歴ログ（lessonLogs）コレクション
+      match /lessonLogs/{logId} {
+        allow read, write: if isAuthenticated() && isOwner(userId);
+      }
     }
 
     // その他のすべてのドキュメントへのアクセスを拒否


### PR DESCRIPTION
## ナビゲーション変更
- 「単元分析」タブ → 「🏠 ダッシュボード」に改称
- 「📝 PDF問題管理」タブを削除
- 「📘 SAPIX」タブ → 「📘 サピックス課題」に改称
- タブ順序を整理: スケジュール/サピックス課題/過去問/テスト成績/ダッシュボード

## ダッシュボードのサブタブ再編
- 🏠 単元ダッシュボード (MasterUnitDashboard) [新規]
  - 50マスター単元の習熟度を色分けグリッドで俯瞰
  - 時間減衰加重平均による習熟度スコア計算
  - 練習記録モーダル（正解/不正解または得点率）
- 📊 学習分析 (Analytics + WeaknessAnalysis 統合)
- ✏️ 単元編集 (MasterUnitEditor) [新規]
  - masterUnits コレクションを Firestore で直接 CRUD
  - 単元ID/名前/カテゴリ/難易度/説明を編集

## 新規ファイル
- utils/lessonLogs.js: 学習ログ統合管理 + 習熟度計算ロジック
  - addLessonLog / getLessonLogs / getLessonLogsByUnit
  - computeProficiencyScore (時間減衰加重平均、半減期90日)
  - computeAllProficiencies / getProficiencyLevel
- components/MasterUnitDashboard.jsx + .css
- components/MasterUnitEditor.jsx + .css

## Firebase変更
- firestore.rules: lessonLogs コレクションを追加

https://claude.ai/code/session_01TdzUBCnxia3ienbEbhZLfs