### PR TITLE
feat: master unit system overhaul with proficiency tracking

### DIFF
--- a/child-learning-app/src/components/MasterUnitDashboard.css
+++ b/child-learning-app/src/components/MasterUnitDashboard.css
@@ -343,3 +343,160 @@
     gap: 12px;
   }
 }
+
+/* ドリルダウンモーダル */
+.mud-drill-modal {
+  max-width: 480px;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.mud-drill-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 14px;
+}
+
+.mud-drill-header h3 {
+  margin: 0 0 4px;
+  font-size: 20px;
+}
+
+.mud-drill-cat {
+  font-size: 12px;
+  color: #6b7280;
+  margin: 0 0 2px;
+}
+
+.mud-drill-score {
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.mud-drill-close {
+  background: none;
+  border: none;
+  font-size: 22px;
+  color: #9ca3af;
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+}
+
+/* 練習記録ボタン行 */
+.mud-drill-practice {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px;
+  background: #f9fafb;
+  border-radius: 8px;
+  margin-bottom: 16px;
+}
+
+.mud-drill-practice-label {
+  font-size: 12px;
+  color: #6b7280;
+  flex-shrink: 0;
+}
+
+.mud-drill-eval-btn {
+  padding: 4px 12px;
+  border: 2px solid transparent;
+  border-radius: 20px;
+  background: white;
+  font-size: 18px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.mud-drill-eval-btn.selected {
+  border-color: var(--eval-color, #3b82f6);
+  background: #f0f9ff;
+}
+
+.mud-drill-eval-btn:hover:not(.selected) {
+  background: #f3f4f6;
+}
+
+.mud-drill-save-btn {
+  padding: 6px 14px;
+  background: #3b82f6;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  margin-left: auto;
+}
+
+.mud-drill-save-btn:hover:not(:disabled) {
+  background: #2563eb;
+}
+
+/* 履歴リスト */
+.mud-drill-history {
+  overflow-y: auto;
+  flex: 1;
+}
+
+.mud-drill-history h4 {
+  font-size: 14px;
+  color: #374151;
+  margin: 0 0 10px;
+}
+
+.mud-drill-loading,
+.mud-drill-empty {
+  text-align: center;
+  color: #9ca3af;
+  font-size: 13px;
+  padding: 20px 0;
+}
+
+.mud-drill-log-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.mud-drill-log-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  background: #f9fafb;
+  border-radius: 6px;
+}
+
+.mud-log-emoji {
+  font-size: 18px;
+  flex-shrink: 0;
+}
+
+.mud-log-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.mud-log-source {
+  font-size: 12px;
+  color: #374151;
+}
+
+.mud-log-score {
+  font-size: 11px;
+  color: #6b7280;
+}
+
+.mud-log-date {
+  font-size: 11px;
+  color: #9ca3af;
+  flex-shrink: 0;
+}

--- a/child-learning-app/src/components/MasterUnitEditor.css
+++ b/child-learning-app/src/components/MasterUnitEditor.css
@@ -21,6 +21,43 @@
   color: #6b7280;
 }
 
+.mue-header-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.mue-init-btn {
+  padding: 9px 14px;
+  background: white;
+  color: #6b7280;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.mue-init-btn:hover:not(:disabled) {
+  background: #fef3c7;
+  border-color: #d97706;
+  color: #92400e;
+}
+
+.mue-init-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.mue-init-progress {
+  padding: 8px 12px;
+  background: #fffbeb;
+  border: 1px solid #fde68a;
+  border-radius: 6px;
+  font-size: 13px;
+  color: #92400e;
+  margin-bottom: 14px;
+}
+
 .mue-add-btn {
   padding: 9px 18px;
   background: #3b82f6;

--- a/child-learning-app/src/components/SapixTextView.css
+++ b/child-learning-app/src/components/SapixTextView.css
@@ -433,3 +433,53 @@
     font-size: 0.75rem;
   }
 }
+
+/* 評価ボタン */
+.sapix-eval-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid #f3f4f6;
+}
+
+.sapix-eval-label {
+  font-size: 12px;
+  color: #6b7280;
+  flex-shrink: 0;
+}
+
+.sapix-eval-btn {
+  padding: 4px 12px;
+  border: 1px solid #e5e7eb;
+  border-radius: 20px;
+  background: white;
+  font-size: 16px;
+  cursor: pointer;
+  transition: all 0.15s;
+  line-height: 1;
+}
+
+.sapix-eval-btn:hover:not(:disabled) {
+  background: #f3f4f6;
+  transform: scale(1.1);
+}
+
+.sapix-eval-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.sapix-eval-saving {
+  font-size: 12px;
+  color: #3b82f6;
+}
+
+/* 単元タグ（複数表示） */
+.sapix-unit-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 4px;
+}

--- a/child-learning-app/src/components/UnitTagPicker.css
+++ b/child-learning-app/src/components/UnitTagPicker.css
@@ -1,0 +1,206 @@
+.utp-root {
+  position: relative;
+  width: 100%;
+}
+
+/* トリガー（選択済み表示エリア） */
+.utp-trigger {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  background: white;
+  cursor: pointer;
+  min-height: 40px;
+  user-select: none;
+  transition: border-color 0.15s;
+}
+
+.utp-trigger:hover,
+.utp-trigger.open {
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+.utp-placeholder {
+  color: #9ca3af;
+  font-size: 13px;
+  flex: 1;
+}
+
+.utp-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  flex: 1;
+}
+
+.utp-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 2px 8px 2px 8px;
+  background: #dbeafe;
+  color: #1d4ed8;
+  border-radius: 12px;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.utp-chip-remove {
+  background: none;
+  border: none;
+  color: #1d4ed8;
+  cursor: pointer;
+  font-size: 13px;
+  padding: 0;
+  line-height: 1;
+  opacity: 0.6;
+}
+
+.utp-chip-remove:hover {
+  opacity: 1;
+}
+
+.utp-arrow {
+  color: #9ca3af;
+  font-size: 10px;
+  flex-shrink: 0;
+}
+
+/* ドロップダウン */
+.utp-dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  background: white;
+  border: 1px solid #d1d5db;
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+  z-index: 200;
+  display: flex;
+  flex-direction: column;
+  max-height: 360px;
+}
+
+/* 検索 */
+.utp-search {
+  display: flex;
+  align-items: center;
+  padding: 8px;
+  border-bottom: 1px solid #f3f4f6;
+  flex-shrink: 0;
+}
+
+.utp-search-input {
+  flex: 1;
+  border: none;
+  outline: none;
+  font-size: 14px;
+  color: #1f2937;
+  background: transparent;
+}
+
+.utp-clear {
+  background: none;
+  border: none;
+  color: #9ca3af;
+  cursor: pointer;
+  font-size: 16px;
+  padding: 0 4px;
+}
+
+/* リスト */
+.utp-list {
+  overflow-y: auto;
+  flex: 1;
+  padding: 4px 0;
+}
+
+.utp-empty {
+  padding: 20px;
+  text-align: center;
+  color: #9ca3af;
+  font-size: 13px;
+}
+
+.utp-group {
+  margin-bottom: 2px;
+}
+
+.utp-group-label {
+  padding: 6px 12px 3px;
+  font-size: 11px;
+  font-weight: 700;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: #f9fafb;
+  position: sticky;
+  top: 0;
+}
+
+.utp-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 12px;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.utp-item:hover {
+  background: #f0f9ff;
+}
+
+.utp-checkbox {
+  width: 15px;
+  height: 15px;
+  cursor: pointer;
+  accent-color: #3b82f6;
+  flex-shrink: 0;
+}
+
+.utp-item-name {
+  flex: 1;
+  font-size: 13px;
+  color: #1f2937;
+}
+
+.utp-item-diff {
+  font-size: 11px;
+  color: #f59e0b;
+}
+
+/* フッター */
+.utp-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 12px;
+  border-top: 1px solid #f3f4f6;
+  flex-shrink: 0;
+}
+
+.utp-footer span {
+  font-size: 12px;
+  color: #6b7280;
+}
+
+.utp-done {
+  padding: 5px 14px;
+  background: #3b82f6;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.utp-done:hover {
+  background: #2563eb;
+}

--- a/child-learning-app/src/components/UnitTagPicker.jsx
+++ b/child-learning-app/src/components/UnitTagPicker.jsx
@@ -1,0 +1,163 @@
+import { useState, useEffect, useMemo } from 'react'
+import { collection, query, orderBy, getDocs, where } from 'firebase/firestore'
+import { db } from '../firebase'
+import './UnitTagPicker.css'
+
+/**
+ * マスター単元の複数選択タグピッカー
+ *
+ * @param {string[]} value - 選択済みの unitId 配列
+ * @param {Function} onChange - (unitIds: string[]) => void
+ * @param {string} [placeholder] - 検索ボックスのプレースホルダー
+ */
+function UnitTagPicker({ value = [], onChange, placeholder = '単元を検索...' }) {
+  const [allUnits, setAllUnits] = useState([])
+  const [searchText, setSearchText] = useState('')
+  const [isOpen, setIsOpen] = useState(false)
+
+  useEffect(() => {
+    loadUnits()
+  }, [])
+
+  const loadUnits = async () => {
+    try {
+      const q = query(
+        collection(db, 'masterUnits'),
+        where('isActive', '==', true),
+        orderBy('orderIndex')
+      )
+      const snapshot = await getDocs(q)
+      setAllUnits(snapshot.docs.map(d => ({ id: d.id, ...d.data() })))
+    } catch {
+      // orderIndex インデックスがない場合はシンプルに取得
+      try {
+        const snapshot = await getDocs(collection(db, 'masterUnits'))
+        setAllUnits(snapshot.docs.map(d => ({ id: d.id, ...d.data() })))
+      } catch (e) {
+        console.error('masterUnits 取得エラー:', e)
+      }
+    }
+  }
+
+  const filteredUnits = useMemo(() => {
+    if (!searchText.trim()) return allUnits
+    const q = searchText.toLowerCase()
+    return allUnits.filter(u =>
+      u.name?.toLowerCase().includes(q) ||
+      u.category?.toLowerCase().includes(q) ||
+      u.id?.toLowerCase().includes(q)
+    )
+  }, [allUnits, searchText])
+
+  const selectedUnits = useMemo(() =>
+    allUnits.filter(u => value.includes(u.id)),
+    [allUnits, value]
+  )
+
+  const handleToggle = (unitId) => {
+    if (value.includes(unitId)) {
+      onChange(value.filter(id => id !== unitId))
+    } else {
+      onChange([...value, unitId])
+    }
+  }
+
+  const handleRemove = (unitId, e) => {
+    e.stopPropagation()
+    onChange(value.filter(id => id !== unitId))
+  }
+
+  // カテゴリでグループ化
+  const groupedFiltered = useMemo(() => {
+    const groups = {}
+    for (const unit of filteredUnits) {
+      const cat = unit.category || 'その他'
+      if (!groups[cat]) groups[cat] = []
+      groups[cat].push(unit)
+    }
+    return groups
+  }, [filteredUnits])
+
+  return (
+    <div className="utp-root">
+      {/* 選択済みタグ表示 + 開閉トリガー */}
+      <div
+        className={`utp-trigger ${isOpen ? 'open' : ''}`}
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        {selectedUnits.length === 0 ? (
+          <span className="utp-placeholder">単元タグを選択（複数可）</span>
+        ) : (
+          <div className="utp-chips">
+            {selectedUnits.map(unit => (
+              <span key={unit.id} className="utp-chip">
+                {unit.name}
+                <button
+                  className="utp-chip-remove"
+                  onClick={(e) => handleRemove(unit.id, e)}
+                  tabIndex={-1}
+                >×</button>
+              </span>
+            ))}
+          </div>
+        )}
+        <span className="utp-arrow">{isOpen ? '▲' : '▼'}</span>
+      </div>
+
+      {/* ドロップダウン */}
+      {isOpen && (
+        <div className="utp-dropdown">
+          <div className="utp-search">
+            <input
+              type="text"
+              className="utp-search-input"
+              placeholder={placeholder}
+              value={searchText}
+              onChange={e => setSearchText(e.target.value)}
+              autoFocus
+              onClick={e => e.stopPropagation()}
+            />
+            {searchText && (
+              <button className="utp-clear" onClick={() => setSearchText('')}>×</button>
+            )}
+          </div>
+
+          <div className="utp-list">
+            {Object.entries(groupedFiltered).length === 0 ? (
+              <div className="utp-empty">「{searchText}」に一致する単元がありません</div>
+            ) : (
+              Object.entries(groupedFiltered).map(([cat, units]) => (
+                <div key={cat} className="utp-group">
+                  <div className="utp-group-label">{cat}</div>
+                  {units.map(unit => (
+                    <label key={unit.id} className="utp-item">
+                      <input
+                        type="checkbox"
+                        className="utp-checkbox"
+                        checked={value.includes(unit.id)}
+                        onChange={() => handleToggle(unit.id)}
+                      />
+                      <span className="utp-item-name">{unit.name}</span>
+                      {unit.difficultyLevel && (
+                        <span className="utp-item-diff">
+                          {'★'.repeat(unit.difficultyLevel)}
+                        </span>
+                      )}
+                    </label>
+                  ))}
+                </div>
+              ))
+            )}
+          </div>
+
+          <div className="utp-footer">
+            <span>{value.length}個選択中</span>
+            <button className="utp-done" onClick={() => setIsOpen(false)}>完了</button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default UnitTagPicker

--- a/firestore.rules
+++ b/firestore.rules
@@ -16,12 +16,9 @@ service cloud.firestore {
     // 弱点分析システム
     // ========================================
 
-    // 単元マスタ（全員読み取り可、ログイン済みユーザーは作成可）
-    // ⚠️ セキュリティ注意: 初期データインポート後は create を false に変更することを推奨
+    // 単元マスタ（認証済みユーザーが管理・編集可能）
     match /masterUnits/{unitId} {
-      allow read: if isAuthenticated();
-      allow create: if isAuthenticated(); // iPhoneからのインポートを許可
-      allow update, delete: if false; // 更新・削除は不可
+      allow read, write: if isAuthenticated();
     }
 
     // 過去問マスタ（全員読み取り可、書き込み不可）
@@ -109,6 +106,11 @@ service cloud.firestore {
 
       // 学習履歴ログ（lessonLogs）コレクション
       match /lessonLogs/{logId} {
+        allow read, write: if isAuthenticated() && isOwner(userId);
+      }
+
+      // マスター単元習熟度統計（masterUnitStats）コレクション
+      match /masterUnitStats/{unitId} {
         allow read, write: if isAuthenticated() && isOwner(userId);
       }
     }


### PR DESCRIPTION
- lessonLogs.js: rewrite with EVALUATION_SCORES (blue=90/yellow=65/red=30), time-decay proficiency (half-life 90 days), addLessonLogWithStats, getMasterUnitStats, getLessonLogsByUnit, getProficiencyLevel
- firestore.rules: add masterUnitStats + lessonLogs subcollections, allow full CRUD on masterUnits for authenticated users
- UnitTagPicker: new multi-select component for 50 master units with search, category grouping, and chip display
- SapixTextView: switch to multi-select unitIds, add UnitTagPicker, add post-registration evaluation buttons (🔵/🟡/🔴)
- MasterUnitDashboard: load from masterUnitStats, 50-unit color grid, drill-down modal with evaluation history and inline practice recording
- MasterUnitEditor: add 50-unit initialization button via importMasterUnitsToFirestore

https://claude.ai/code/session_01TdzUBCnxia3ienbEbhZLfs