### PR TITLE
feat: simplify past paper form — school+year only, master unit multi-…

### DIFF
--- a/child-learning-app/src/components/PastPaperView.css
+++ b/child-learning-app/src/components/PastPaperView.css
@@ -892,15 +892,97 @@
   gap: 3px;
 }
 
+/* カード内の単元タグ表示 */
+.task-unit-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 4px;
+}
+
 .unit-tag {
   display: inline-block;
   background: #dbeafe;
   color: #1e40af;
-  padding: 1px 6px;
-  border-radius: 3px;
+  padding: 1px 7px;
+  border-radius: 10px;
   font-size: 0.65rem;
   font-weight: 500;
   border: 1px solid #bfdbfe;
+}
+
+/* 単元タグセレクター（フォーム内） */
+.unit-tags-selector {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 280px;
+  overflow-y: auto;
+  padding: 10px 12px;
+  background: #f8fafc;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+}
+
+.unit-tag-category {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.unit-tag-cat-label {
+  font-size: 11px;
+  font-weight: 700;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.unit-tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.unit-tag-btn {
+  padding: 3px 10px;
+  border: 1px solid #d1d5db;
+  border-radius: 12px;
+  background: white;
+  color: #374151;
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 0.1s, border-color 0.1s, color 0.1s;
+}
+
+.unit-tag-btn:hover {
+  background: #eff6ff;
+  border-color: #93c5fd;
+  color: #1d4ed8;
+}
+
+.unit-tag-btn.selected {
+  background: #dbeafe;
+  border-color: #2563eb;
+  color: #1d4ed8;
+  font-weight: 600;
+}
+
+.unit-selected-count {
+  margin-left: 8px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #2563eb;
+  background: #dbeafe;
+  padding: 1px 7px;
+  border-radius: 10px;
+}
+
+.unit-tags-empty {
+  color: #9ca3af;
+  font-size: 13px;
+  margin: 0;
+  padding: 8px 0;
 }
 
 /* 最新セッション */


### PR DESCRIPTION
…tags

- Remove grade and round fields from add/edit forms
- Title format changed to "{schoolName} {year}"
- Validation now requires only schoolName + year
- Replace single unitId (radio) with unitIds[] (multi-select tag style)
  - Master units loaded from getStaticMasterUnits(), grouped by category
  - Clickable pill tags for each unit; selected count shown in label
  - Subject switch resets unitIds
- groupByUnit() updated to handle unitIds[] (a task tagged to N units appears under each unit group)
- Backwards compat: old tasks with unitId field are read via getTaskUnitIds()
- getUnitName() now searches masterUnits first, then customUnits
- renderFileArea() helper deduplicates add/edit PDF upload UI
- Added CSS: .task-unit-tags, .unit-tags-selector, .unit-tag-btn, .unit-tag-category, .unit-tag-cat-label, .unit-selected-count, .unit-tags-empty

https://claude.ai/code/session_01TdzUBCnxia3ienbEbhZLfs