### PR TITLE
fix: SAPIX eval→dashboard sync; remove 学習分析 tab; TaskForm master unit…

### DIFF
--- a/child-learning-app/src/components/UnitAnalysisView.jsx
+++ b/child-learning-app/src/components/UnitAnalysisView.jsx
@@ -1,38 +1,10 @@
-import { useState } from 'react'
-import '../components/ScheduleView.css'
+import './ScheduleView.css'
 import MasterUnitDashboard from './MasterUnitDashboard'
-import Analytics from './Analytics'
-import WeaknessAnalysis from './WeaknessAnalysis'
 
-function UnitAnalysisView({ tasks }) {
-  const [subView, setSubView] = useState('dashboard') // 'dashboard' | 'analysis'
-
+function UnitAnalysisView() {
   return (
     <div className="unit-analysis-view">
-      <div className="sub-tab-switcher">
-        <button
-          className={subView === 'dashboard' ? 'active' : ''}
-          onClick={() => setSubView('dashboard')}
-        >
-          🏠 単元ダッシュボード
-        </button>
-        <button
-          className={subView === 'analysis' ? 'active' : ''}
-          onClick={() => setSubView('analysis')}
-        >
-          📊 学習分析
-        </button>
-      </div>
-
-      {subView === 'dashboard' ? (
-        <MasterUnitDashboard />
-      ) : (
-        <div className="study-analysis">
-          <Analytics tasks={tasks} />
-          <div className="analysis-divider" />
-          <WeaknessAnalysis />
-        </div>
-      )}
+      <MasterUnitDashboard />
     </div>
   )
 }


### PR DESCRIPTION
… tags

[Fix] lessonLogs.js: getLessonLogsByUnit — remove orderBy('createdAt','desc')
  which required a Firestore composite index. Without the index, the query
  threw an error silently inside updateMasterUnitStats(), preventing
  masterUnitStats from being written → evaluation never showed in dashboard.
  Results are now sorted client-side so behavior is identical.

[Remove] UnitAnalysisView: drop 学習分析 (Analytics + WeaknessAnalysis)
  sub-tab entirely. Component now renders MasterUnitDashboard directly
  with no sub-tab switcher.

[Feature] TaskForm: replace grade selector + unitsDatabase <select> +
  CustomUnitForm with UnitTagPicker (master units, multi-select).
  - unitId (single string) → unitIds (string[])
  - grade field removed from form; saved as '全学年'
  - unitId kept in saved data as unitIds[0] for backwards compat
  - Removed: getUnitName, handleAddCustomUnit, grade/customUnit states
  - PastPaperFields still rendered for pastpaper type; currentUnits=[]

https://claude.ai/code/session_01TdzUBCnxia3ienbEbhZLfs