### PR TITLE
fix: remove orderBy from getLessonLogs to avoid missing Firestore index

### DIFF
--- a/child-learning-app/src/utils/lessonLogs.js
+++ b/child-learning-app/src/utils/lessonLogs.js
@@ -97,11 +97,17 @@ export async function addLessonLog(userId, data) {
 export async function getLessonLogs(userId) {
   try {
     const q = query(
-      collection(db, 'users', userId, 'lessonLogs'),
-      orderBy('createdAt', 'desc')
+      collection(db, 'users', userId, 'lessonLogs')
+      // orderBy は Firestore インデックスを要求するため除去。クライアント側でソートする
     )
     const snapshot = await getDocs(q)
-    const data = snapshot.docs.map(d => ({ id: d.id, ...d.data() }))
+    const data = snapshot.docs
+      .map(d => ({ id: d.id, ...d.data() }))
+      .sort((a, b) => {
+        const ta = a.createdAt?.toMillis?.() ?? new Date(a.createdAt ?? 0).getTime()
+        const tb = b.createdAt?.toMillis?.() ?? new Date(b.createdAt ?? 0).getTime()
+        return tb - ta
+      })
     return { success: true, data }
   } catch (error) {
     console.error('lessonLog 取得エラー:', error)


### PR DESCRIPTION
getLessonLogs used orderBy('createdAt', 'desc') which requires a Firestore single-field index that may not exist, causing the query to silently fail and return { success: false }. This caused MasterUnitDashboard to receive an empty logs array, so computeAllProficiencies returned {} and all units showed as 未学習 even after recording evaluations.

Fix: remove orderBy and sort client-side (same approach as getLessonLogsByUnit).

https://claude.ai/code/session_01TdzUBCnxia3ienbEbhZLfs