### PR TITLE
fix: use static master units data instead of Firestore to avoid permi…

### DIFF
--- a/child-learning-app/src/components/MasterUnitDashboard.jsx
+++ b/child-learning-app/src/components/MasterUnitDashboard.jsx
@@ -1,8 +1,6 @@
 import { useState, useEffect } from 'react'
 import { getAuth } from 'firebase/auth'
-import { collection, getDocs } from 'firebase/firestore'
-import { db } from '../firebase'
-import { getStaticMasterUnits, ensureMasterUnitsSeeded } from '../utils/importMasterUnits'
+import { getStaticMasterUnits } from '../utils/importMasterUnits'
 import {
   getLessonLogs,
   computeAllProficiencies,
@@ -62,7 +60,7 @@ function MasterUnitDashboard() {
       if (!userId) return
 
       const [units, logsResult] = await Promise.all([
-        loadMasterUnits(),
+        Promise.resolve(getStaticMasterUnits()),
         getLessonLogs(userId),
       ])
 
@@ -86,20 +84,6 @@ function MasterUnitDashboard() {
       console.error('データ取得エラー:', err)
     } finally {
       setLoading(false)
-    }
-  }
-
-  const loadMasterUnits = async () => {
-    try {
-      await ensureMasterUnitsSeeded()
-      const snapshot = await getDocs(collection(db, 'masterUnits'))
-      if (snapshot.empty) return getStaticMasterUnits()
-      return snapshot.docs
-        .map(d => ({ id: d.id, ...d.data() }))
-        .filter(u => u.isActive !== false)
-        .sort((a, b) => (a.orderIndex || 0) - (b.orderIndex || 0))
-    } catch {
-      return getStaticMasterUnits()
     }
   }
 

--- a/child-learning-app/src/components/UnitTagPicker.jsx
+++ b/child-learning-app/src/components/UnitTagPicker.jsx
@@ -1,7 +1,5 @@
-import { useState, useEffect, useMemo } from 'react'
-import { collection, getDocs } from 'firebase/firestore'
-import { db } from '../firebase'
-import { getStaticMasterUnits, ensureMasterUnitsSeeded } from '../utils/importMasterUnits'
+import { useState, useMemo } from 'react'
+import { getStaticMasterUnits } from '../utils/importMasterUnits'
 import './UnitTagPicker.css'
 
 /**
@@ -12,34 +10,9 @@ import './UnitTagPicker.css'
  * @param {string} [placeholder] - 検索ボックスのプレースホルダー
  */
 function UnitTagPicker({ value = [], onChange, placeholder = '単元を検索...' }) {
-  const [allUnits, setAllUnits] = useState([])
+  const allUnits = getStaticMasterUnits()
   const [searchText, setSearchText] = useState('')
   const [isOpen, setIsOpen] = useState(false)
-
-  useEffect(() => {
-    loadUnits()
-  }, [])
-
-  const loadUnits = async () => {
-    try {
-      // コレクション未シードの場合は自動初期化
-      await ensureMasterUnitsSeeded()
-      const snapshot = await getDocs(collection(db, 'masterUnits'))
-      if (snapshot.empty) {
-        // Firestoreへの書き込み権限がない場合は静的データにフォールバック
-        setAllUnits(getStaticMasterUnits())
-        return
-      }
-      const units = snapshot.docs
-        .map(d => ({ id: d.id, ...d.data() }))
-        .filter(u => u.isActive !== false)
-        .sort((a, b) => (a.orderIndex || 0) - (b.orderIndex || 0))
-      setAllUnits(units)
-    } catch (e) {
-      console.error('masterUnits 取得エラー:', e)
-      setAllUnits(getStaticMasterUnits())
-    }
-  }
 
   const filteredUnits = useMemo(() => {
     if (!searchText.trim()) return allUnits


### PR DESCRIPTION
…ssion errors

MasterUnitDashboard and UnitTagPicker were trying to read /masterUnits collection from Firestore, causing "Missing or insufficient permissions" errors. Since all master unit data is already available via getStaticMasterUnits(), removed the Firestore read entirely. This eliminates the error and removes the dependency on Firestore rules for master unit display.

https://claude.ai/code/session_01TdzUBCnxia3ienbEbhZLfs