### PR TITLE
fix: properly handle addLessonLogWithStats return value and add debug…

### DIFF
--- a/child-learning-app/src/components/MasterUnitDashboard.jsx
+++ b/child-learning-app/src/components/MasterUnitDashboard.jsx
@@ -66,7 +66,11 @@ function MasterUnitDashboard() {
 
       setMasterUnits(units)
 
+      if (!logsResult.success) {
+        console.error('lessonLogs 読み取り失敗:', logsResult.error)
+      }
       const logs = logsResult.success ? logsResult.data : []
+      console.log(`lessonLogs: ${logs.length}件取得`)
       setAllLogs(logs)
 
       // lessonLogs から直接習熟度を計算（masterUnitStats に依存しない）
@@ -102,7 +106,7 @@ function MasterUnitDashboard() {
 
     setSaving(true)
     try {
-      await addLessonLogWithStats(userId, {
+      const result = await addLessonLogWithStats(userId, {
         unitIds: [practiceUnit.id],
         sourceType: 'practice',
         sourceName: practiceUnit.name,
@@ -110,9 +114,12 @@ function MasterUnitDashboard() {
         performance: EVALUATION_SCORES[practiceEval],
         evaluationKey: practiceEval,
       })
+      if (!result.success) {
+        console.error('練習記録エラー:', result.error)
+        return
+      }
       setPracticeUnit(null)
       setPracticeEval(null)
-      // lessonLogs を再読み込みして統計を再計算（drillLogs も自動更新される）
       await loadData()
     } catch (err) {
       console.error('記録エラー:', err)

--- a/child-learning-app/src/components/SapixTextView.jsx
+++ b/child-learning-app/src/components/SapixTextView.jsx
@@ -119,7 +119,7 @@ function SapixTextView({ user }) {
     }
     setEvaluating(text.firestoreId)
     try {
-      await addLessonLogWithStats(user.uid, {
+      const result = await addLessonLogWithStats(user.uid, {
         unitIds: text.unitIds,
         sourceType: 'sapixTask',
         sourceId: text.firestoreId,
@@ -128,7 +128,12 @@ function SapixTextView({ user }) {
         performance: EVALUATION_SCORES[evalKey],
         evaluationKey: evalKey,
       })
-      toast.success(`評価を記録しました: ${EVALUATION_LABELS[evalKey]}`)
+      if (result.success) {
+        toast.success(`評価を記録しました: ${EVALUATION_LABELS[evalKey]}`)
+      } else {
+        toast.error('評価の記録に失敗しました: ' + result.error)
+        console.error('addLessonLogWithStats failed:', result.error)
+      }
     } catch (err) {
       toast.error('評価の記録に失敗しました')
       console.error(err)


### PR DESCRIPTION
… logging

- SapixTextView: check result.success before showing success toast; previously evaluation failures were silently swallowed and a success message was shown even when the Firestore write failed
- MasterUnitDashboard: same fix for handleSavePractice; also add console.log to show lessonLogs count and surface read errors visibly

https://claude.ai/code/session_01TdzUBCnxia3ienbEbhZLfs