### PR TITLE
feat: redesign TestScoreView as strategic hub with problem logs and r…

### DIFF
--- a/child-learning-app/src/components/TestScoreView.css
+++ b/child-learning-app/src/components/TestScoreView.css
@@ -599,3 +599,623 @@
     flex-wrap: wrap;
   }
 }
+
+/* ============================================================
+   詳細ビュー
+   ============================================================ */
+
+.score-card-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.btn-open-detail {
+  width: 100%;
+  padding: 10px 16px;
+  background: #f0f7ff;
+  color: #007AFF;
+  border: 1px solid #bfdbfe;
+  border-top: none;
+  border-radius: 0 0 16px 16px;
+  font-weight: 600;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  text-align: center;
+}
+
+.btn-open-detail:hover {
+  background: #dbeafe;
+  color: #0057cc;
+}
+
+/* 詳細ヘッダー */
+.detail-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  background: white;
+  border-radius: 16px;
+  padding: 16px 20px;
+  margin-bottom: 16px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+  border: 1px solid rgba(0,0,0,0.06);
+  flex-wrap: wrap;
+}
+
+.back-btn {
+  padding: 8px 16px;
+  background: white;
+  border: 1px solid rgba(0,0,0,0.12);
+  border-radius: 10px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  color: #64748b;
+  white-space: nowrap;
+  transition: all 0.2s;
+  flex-shrink: 0;
+}
+
+.back-btn:hover {
+  background: #f5f5f7;
+  border-color: rgba(0,0,0,0.2);
+}
+
+.detail-title-area {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.detail-test-name {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #1d1d1f;
+  margin: 0;
+}
+
+.detail-test-date {
+  font-size: 0.875rem;
+  color: #64748b;
+}
+
+.detail-deviation-badge {
+  background: linear-gradient(135deg, #3b82f6, #60a5fa);
+  color: white;
+  padding: 4px 12px;
+  border-radius: 20px;
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.detail-header-actions {
+  flex-shrink: 0;
+}
+
+.btn-edit-score {
+  padding: 8px 16px;
+  background: white;
+  border: 1px solid rgba(0,0,0,0.12);
+  border-radius: 10px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  cursor: pointer;
+  color: #475569;
+  transition: all 0.2s;
+}
+
+.btn-edit-score:hover {
+  background: #f5f5f7;
+}
+
+/* アクションバー */
+.action-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: white;
+  border-radius: 14px;
+  padding: 14px 20px;
+  margin-bottom: 16px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+  border: 1px solid rgba(0,0,0,0.06);
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.action-bar-info {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.problem-count-badge {
+  background: #f1f5f9;
+  color: #475569;
+  padding: 4px 12px;
+  border-radius: 20px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.revenge-count-badge {
+  background: #fff7ed;
+  color: #ea580c;
+  padding: 4px 12px;
+  border-radius: 20px;
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.action-bar-buttons {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.btn-sync-units {
+  padding: 10px 16px;
+  background: #fee2e2;
+  color: #dc2626;
+  border: 1px solid #fca5a5;
+  border-radius: 10px;
+  font-size: 0.875rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.2s;
+  white-space: nowrap;
+}
+
+.btn-sync-units:hover:not(:disabled) {
+  background: #fecaca;
+}
+
+.btn-sync-units:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-create-tasks {
+  padding: 10px 16px;
+  background: #007AFF;
+  color: white;
+  border: none;
+  border-radius: 10px;
+  font-size: 0.875rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.2s;
+  box-shadow: 0 2px 6px rgba(0,122,255,0.25);
+  white-space: nowrap;
+}
+
+.btn-create-tasks:hover:not(:disabled) {
+  background: #0071e3;
+}
+
+.btn-create-tasks:disabled {
+  background: #94a3b8;
+  box-shadow: none;
+  cursor: not-allowed;
+}
+
+/* セクションカード */
+.section-card {
+  background: white;
+  border-radius: 16px;
+  padding: 20px;
+  margin-bottom: 16px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+  border: 1px solid rgba(0,0,0,0.06);
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+  gap: 12px;
+}
+
+.section-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #1e293b;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.revenge-subtitle {
+  font-size: 0.78rem;
+  font-weight: 500;
+  color: #94a3b8;
+}
+
+.btn-add-problem {
+  padding: 8px 16px;
+  background: #007AFF;
+  color: white;
+  border: none;
+  border-radius: 10px;
+  font-size: 0.875rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.2s;
+  white-space: nowrap;
+}
+
+.btn-add-problem:hover {
+  background: #0071e3;
+  transform: translateY(-1px);
+}
+
+.empty-problems {
+  text-align: center;
+  padding: 32px 20px;
+  color: #94a3b8;
+  font-size: 0.9rem;
+  background: #f8fafc;
+  border-radius: 12px;
+}
+
+/* 問題テーブル */
+.problem-table-wrapper {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.problem-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.problem-table th {
+  text-align: left;
+  padding: 8px 12px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: #94a3b8;
+  border-bottom: 2px solid #f1f5f9;
+  white-space: nowrap;
+}
+
+.problem-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid #f1f5f9;
+  vertical-align: middle;
+}
+
+.problem-row {
+  transition: background 0.15s;
+}
+
+.problem-row:hover {
+  background: #f8fafc;
+}
+
+.wrong-row {
+  background: rgba(254, 226, 226, 0.3);
+}
+
+.wrong-row:hover {
+  background: rgba(254, 226, 226, 0.5);
+}
+
+.revenge-row {
+  background: rgba(255, 237, 213, 0.4) !important;
+}
+
+.revenge-row:hover {
+  background: rgba(255, 237, 213, 0.6) !important;
+}
+
+.cell-num {
+  font-weight: 700;
+  color: #1e293b;
+  white-space: nowrap;
+}
+
+.revenge-marker {
+  margin-left: 4px;
+  font-size: 0.75rem;
+}
+
+.subject-chip {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.subject-算数 { background: #dbeafe; color: #1d4ed8; }
+.subject-国語 { background: #fce7f3; color: #9d174d; }
+.subject-理科 { background: #d1fae5; color: #065f46; }
+.subject-社会 { background: #fef3c7; color: #92400e; }
+
+.cell-units {
+  max-width: 200px;
+}
+
+.unit-tag {
+  display: inline-block;
+  background: #f1f5f9;
+  color: #475569;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 0.75rem;
+  margin: 2px;
+  white-space: nowrap;
+}
+
+.no-unit, .no-link {
+  color: #cbd5e1;
+  font-size: 0.875rem;
+}
+
+.correct-rate-badge {
+  display: inline-block;
+  padding: 3px 8px;
+  border-radius: 10px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.correct-mark {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #16a34a;
+}
+
+.wrong-mark {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #dc2626;
+}
+
+.status-select {
+  padding: 4px 8px;
+  border-radius: 8px;
+  border: 1px solid rgba(0,0,0,0.1);
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  outline: none;
+}
+
+.sapix-text-link {
+  display: inline-block;
+  color: #007AFF;
+  text-decoration: none;
+  font-size: 0.78rem;
+  padding: 2px 6px;
+  border-radius: 6px;
+  background: #f0f7ff;
+  border: 1px solid #bfdbfe;
+  transition: all 0.15s;
+  white-space: nowrap;
+  margin: 2px;
+}
+
+.sapix-text-link:hover {
+  background: #dbeafe;
+  border-color: #93c5fd;
+}
+
+.btn-delete-problem {
+  padding: 4px 8px;
+  background: white;
+  border: 1px solid rgba(0,0,0,0.1);
+  border-radius: 6px;
+  cursor: pointer;
+  color: #94a3b8;
+  font-size: 1rem;
+  line-height: 1;
+  transition: all 0.15s;
+}
+
+.btn-delete-problem:hover {
+  background: #fee2e2;
+  border-color: #fca5a5;
+  color: #dc2626;
+}
+
+/* リベンジリスト */
+.revenge-section {
+  border-left: 4px solid #f97316;
+}
+
+.revenge-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.revenge-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 14px 16px;
+  background: #fff7ed;
+  border-radius: 12px;
+  border: 1px solid #fed7aa;
+}
+
+.revenge-rank {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  background: #f97316;
+  color: white;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 800;
+}
+
+.revenge-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.revenge-title {
+  font-weight: 700;
+  color: #1e293b;
+  font-size: 0.95rem;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.revenge-meta {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 6px;
+}
+
+.revenge-rate {
+  font-size: 0.875rem;
+  color: #ea580c;
+}
+
+.revenge-units {
+  font-size: 0.875rem;
+  color: #64748b;
+}
+
+.revenge-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.revenge-status {
+  flex-shrink: 0;
+  align-self: center;
+}
+
+/* 問題追加フォーム */
+.problem-form-container {
+  max-width: 600px !important;
+}
+
+.correct-radio-group {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.radio-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 16px;
+  border-radius: 10px;
+  border: 2px solid rgba(0,0,0,0.1);
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 0.9rem;
+  transition: all 0.15s;
+  background: white;
+}
+
+.radio-btn input[type="radio"] {
+  display: none;
+}
+
+.radio-correct.active {
+  background: #dcfce7;
+  border-color: #16a34a;
+  color: #16a34a;
+}
+
+.radio-wrong.active {
+  background: #fee2e2;
+  border-color: #dc2626;
+  color: #dc2626;
+}
+
+.unit-checkbox-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 6px;
+  max-height: 240px;
+  overflow-y: auto;
+  padding: 12px;
+  background: #f8fafc;
+  border-radius: 10px;
+  border: 1px solid rgba(0,0,0,0.08);
+}
+
+.unit-checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  color: #475569;
+  border: 1px solid transparent;
+  transition: all 0.15s;
+}
+
+.unit-checkbox-label:hover {
+  background: white;
+  border-color: rgba(0,0,0,0.1);
+}
+
+.unit-checkbox-label.checked {
+  background: #eff6ff;
+  border-color: #bfdbfe;
+  color: #1d4ed8;
+  font-weight: 600;
+}
+
+.unit-checkbox-label input[type="checkbox"] {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+@media (max-width: 640px) {
+  .detail-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+  }
+
+  .action-bar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .action-bar-buttons {
+    width: 100%;
+  }
+
+  .btn-sync-units,
+  .btn-create-tasks {
+    flex: 1;
+    text-align: center;
+  }
+
+  .revenge-item {
+    flex-wrap: wrap;
+  }
+}

--- a/child-learning-app/src/components/TestScoreView.jsx
+++ b/child-learning-app/src/components/TestScoreView.jsx
@@ -8,8 +8,15 @@ import {
   deleteTestScore,
   testTypes
 } from '../utils/testScores'
+import { getSapixTexts } from '../utils/sapixTexts'
+import { addLessonLogWithStats, EVALUATION_SCORES } from '../utils/lessonLogs'
+import { addTaskToFirestore } from '../utils/firestore'
+import { getStaticMasterUnits } from '../utils/importMasterUnits'
 import ScoreCard from './ScoreCard'
 import DeviationChart from './DeviationChart'
+import { toast } from '../utils/toast'
+
+const SUBJECTS = ['算数', '国語', '理科', '社会']
 
 function TestScoreView({ user }) {
   const [scores, setScores] = useState([])
@@ -17,6 +24,16 @@ function TestScoreView({ user }) {
   const [showForm, setShowForm] = useState(false)
   const [editingScore, setEditingScore] = useState(null)
   const [scoreForm, setScoreForm] = useState(getEmptyForm())
+
+  // 詳細ビュー
+  const [selectedScore, setSelectedScore] = useState(null)
+  const [showProblemForm, setShowProblemForm] = useState(false)
+  const [problemForm, setProblemForm] = useState(getEmptyProblemForm())
+  const [sapixTexts, setSapixTexts] = useState([])
+  const [syncingUnits, setSyncingUnits] = useState(false)
+  const [creatingTasks, setCreatingTasks] = useState(false)
+
+  const masterUnits = getStaticMasterUnits()
 
   function getEmptyForm() {
     return {
@@ -34,19 +51,41 @@ function TestScoreView({ user }) {
     }
   }
 
+  function getEmptyProblemForm() {
+    return {
+      subject: '算数',
+      problemNumber: '',
+      unitIds: [],
+      correctRate: '',
+      isCorrect: false,
+      points: '',
+    }
+  }
+
   // データ読み込み
   useEffect(() => {
     if (!user) return
-
     const loadScores = async () => {
       const result = await getAllTestScores(user.uid)
-      if (result.success) {
-        setScores(result.data)
-      }
+      if (result.success) setScores(result.data)
     }
-
     loadScores()
   }, [user])
+
+  // 詳細ビューを開いたときSAPIXテキストを読み込む
+  useEffect(() => {
+    if (!user || !selectedScore) return
+    getSapixTexts(user.uid).then(result => {
+      if (result.success) setSapixTexts(result.data)
+    })
+  }, [user, selectedScore?.firestoreId])
+
+  // selectedScoreをscores配列と同期
+  useEffect(() => {
+    if (!selectedScore) return
+    const updated = scores.find(s => s.firestoreId === selectedScore.firestoreId)
+    if (updated) setSelectedScore(updated)
+  }, [scores])
 
   // フィルタリング
   const filteredScores = scores.filter(s => s.grade === selectedGrade)
@@ -58,14 +97,191 @@ function TestScoreView({ user }) {
       .sort((a, b) => new Date(a.testDate) - new Date(b.testDate))
   }, [filteredScores])
 
-  // フォームを開く
+  // ============================================================
+  // 問題ログ ヘルパー
+  // ============================================================
+
+  function getProblemLogs(score) {
+    return score?.problemLogs || []
+  }
+
+  /** 正答率 >= 50% かつ 不正解 → リベンジリスト（正答率降順） */
+  function getRevengeList(score) {
+    return getProblemLogs(score)
+      .filter(p => !p.isCorrect && parseFloat(p.correctRate) >= 50)
+      .sort((a, b) => parseFloat(b.correctRate) - parseFloat(a.correctRate))
+  }
+
+  /** 問題に紐づくSAPIXテキストを取得 */
+  function getLinkedTexts(problem) {
+    if (!problem.unitIds?.length) return []
+    return sapixTexts.filter(t =>
+      (t.unitIds || []).some(uid => problem.unitIds.includes(uid))
+    )
+  }
+
+  /** unitId → 単元名 */
+  function getUnitName(unitId) {
+    const unit = masterUnits.find(u => u.id === unitId)
+    return unit ? unit.name : unitId
+  }
+
+  /** 選択教科のマスター単元（単元タグ選択用） */
+  function getUnitsForSubject(subject) {
+    return masterUnits.filter(u => !u.subject || u.subject === subject)
+  }
+
+  // ============================================================
+  // 問題ログ CRUD
+  // ============================================================
+
+  const handleSaveProblem = async () => {
+    if (!problemForm.problemNumber) {
+      toast.error('問題番号を入力してください')
+      return
+    }
+
+    const newProblem = {
+      id: `problem_${Date.now()}`,
+      subject: problemForm.subject,
+      problemNumber: parseInt(problemForm.problemNumber),
+      unitIds: problemForm.unitIds,
+      correctRate: parseFloat(problemForm.correctRate) || 0,
+      isCorrect: problemForm.isCorrect,
+      reviewStatus: 'pending',
+      points: parseInt(problemForm.points) || null,
+    }
+
+    const currentProblems = getProblemLogs(selectedScore)
+    const updatedProblems = [...currentProblems, newProblem]
+
+    const result = await updateTestScore(user.uid, selectedScore.firestoreId, {
+      problemLogs: updatedProblems
+    })
+
+    if (result.success) {
+      const refreshResult = await getAllTestScores(user.uid)
+      if (refreshResult.success) setScores(refreshResult.data)
+      setProblemForm(getEmptyProblemForm())
+      setShowProblemForm(false)
+      toast.success('問題を追加しました')
+    } else {
+      toast.error('保存に失敗しました')
+    }
+  }
+
+  const handleUpdateProblemStatus = async (problemId, reviewStatus) => {
+    const currentProblems = getProblemLogs(selectedScore)
+    const updatedProblems = currentProblems.map(p =>
+      p.id === problemId ? { ...p, reviewStatus } : p
+    )
+    await updateTestScore(user.uid, selectedScore.firestoreId, { problemLogs: updatedProblems })
+    const refreshResult = await getAllTestScores(user.uid)
+    if (refreshResult.success) setScores(refreshResult.data)
+  }
+
+  const handleDeleteProblem = async (problemId) => {
+    const currentProblems = getProblemLogs(selectedScore)
+    const updatedProblems = currentProblems.filter(p => p.id !== problemId)
+    await updateTestScore(user.uid, selectedScore.firestoreId, { problemLogs: updatedProblems })
+    const refreshResult = await getAllTestScores(user.uid)
+    if (refreshResult.success) setScores(refreshResult.data)
+    toast.success('削除しました')
+  }
+
+  // ============================================================
+  // マスター単元へ反映（不正解問題 → 🔴 lessonLog）
+  // ============================================================
+
+  const handleSyncToMasterUnits = async () => {
+    const problems = getProblemLogs(selectedScore)
+    const wrongWithUnits = problems.filter(p => !p.isCorrect && p.unitIds?.length > 0)
+
+    if (wrongWithUnits.length === 0) {
+      toast.error('単元タグが設定された不正解問題がありません')
+      return
+    }
+
+    setSyncingUnits(true)
+    try {
+      for (const problem of wrongWithUnits) {
+        await addLessonLogWithStats(user.uid, {
+          unitIds: problem.unitIds,
+          sourceType: 'testScore',
+          sourceId: selectedScore.firestoreId,
+          sourceName: `${selectedScore.testName} 第${problem.problemNumber}問`,
+          date: selectedScore.testDate,
+          performance: EVALUATION_SCORES.red,
+          evaluationKey: 'red',
+          grade: selectedScore.grade,
+          notes: `正答率 ${problem.correctRate}%（テスト結果自動反映）`,
+        })
+      }
+      toast.success(`${wrongWithUnits.length}問をマスター単元に反映しました（🔴 要復習）`)
+    } catch {
+      toast.error('反映に失敗しました')
+    } finally {
+      setSyncingUnits(false)
+    }
+  }
+
+  // ============================================================
+  // リベンジタスク作成（翌週スケジュールへ）
+  // ============================================================
+
+  const handleCreateRevengeTasks = async () => {
+    const revengeList = getRevengeList(selectedScore)
+
+    if (revengeList.length === 0) {
+      toast.error('リベンジリストが空です（正答率50%以上の不正解問題がありません）')
+      return
+    }
+
+    setCreatingTasks(true)
+    try {
+      const nextWeek = new Date()
+      nextWeek.setDate(nextWeek.getDate() + 7)
+      const dueDate = nextWeek.toISOString().split('T')[0]
+
+      for (const problem of revengeList) {
+        const unitNames = problem.unitIds.map(id => getUnitName(id)).join('・')
+        const newTask = {
+          id: Date.now() + Math.random(),
+          title: `【解き直し】${selectedScore.testName} 第${problem.problemNumber}問 (${problem.subject})`,
+          subject: problem.subject,
+          priority: 'A',
+          dueDate: dueDate,
+          notes: `正答率 ${problem.correctRate}%${unitNames ? ` / ${unitNames}` : ''}`,
+          taskType: 'review',
+          completed: false,
+          createdAt: new Date().toISOString(),
+        }
+        await addTaskToFirestore(user.uid, newTask)
+      }
+
+      toast.success(`${revengeList.length}件の解き直しタスクをスケジュールに追加しました`)
+    } catch {
+      toast.error('タスク作成に失敗しました')
+    } finally {
+      setCreatingTasks(false)
+    }
+  }
+
+  // ============================================================
+  // スコア CRUD（既存）
+  // ============================================================
+
+  const handleOpenDetail = (score) => {
+    setSelectedScore(score)
+    setShowProblemForm(false)
+  }
+
   const handleOpenForm = () => {
     setEditingScore(null)
     setScoreForm(getEmptyForm())
     setShowForm(true)
   }
 
-  // 編集フォームを開く
   const handleEditScore = (score) => {
     setEditingScore(score)
     setScoreForm({
@@ -84,15 +300,10 @@ function TestScoreView({ user }) {
     setShowForm(true)
   }
 
-  // 保存
   const handleSave = async () => {
-    if (!user) {
-      alert('❌ ログインが必要です')
-      return
-    }
-
+    if (!user) { toast.error('ログインが必要です'); return }
     if (!scoreForm.testName || !scoreForm.testDate) {
-      alert('❌ テスト名と実施日は必須です')
+      toast.error('テスト名と実施日は必須です')
       return
     }
 
@@ -101,37 +312,643 @@ function TestScoreView({ user }) {
       : await addTestScore(user.uid, scoreForm)
 
     if (result.success) {
-      // データを再読み込み
       const refreshResult = await getAllTestScores(user.uid)
-      if (refreshResult.success) {
-        setScores(refreshResult.data)
-      }
+      if (refreshResult.success) setScores(refreshResult.data)
       setShowForm(false)
-      alert(editingScore ? '✅ 更新しました' : '✅ 保存しました')
+      toast.success(editingScore ? '更新しました' : '保存しました')
     } else {
-      alert('❌ 保存に失敗しました: ' + result.error)
+      toast.error('保存に失敗しました: ' + result.error)
     }
   }
 
-  // 削除
   const handleDelete = async (score) => {
-    if (!window.confirm(`「${score.testName} (${score.testDate})」を削除しますか？`)) {
-      return
-    }
-
+    if (!window.confirm(`「${score.testName} (${score.testDate})」を削除しますか？`)) return
     const result = await deleteTestScore(user.uid, score.firestoreId)
-
     if (result.success) {
       setScores(scores.filter(s => s.firestoreId !== score.firestoreId))
-      alert('✅ 削除しました')
+      if (selectedScore?.firestoreId === score.firestoreId) setSelectedScore(null)
+      toast.success('削除しました')
     } else {
-      alert('❌ 削除に失敗しました: ' + result.error)
+      toast.error('削除に失敗しました')
     }
+  }
+
+  // ============================================================
+  // レビューステータスラベル
+  // ============================================================
+
+  function reviewStatusLabel(status) {
+    if (status === 'done') return { label: '解き直し済', color: '#16a34a', bg: '#dcfce7' }
+    if (status === 'retry') return { label: '要再挑戦', color: '#dc2626', bg: '#fee2e2' }
+    return { label: '未完了', color: '#64748b', bg: '#f1f5f9' }
+  }
+
+  // ============================================================
+  // RENDER - 詳細ビュー
+  // ============================================================
+
+  if (selectedScore) {
+    const problemLogs = getProblemLogs(selectedScore)
+    const revengeList = getRevengeList(selectedScore)
+    const unitsForSubject = getUnitsForSubject(problemForm.subject)
+
+    return (
+      <div className="testscore-view">
+        {/* 詳細ヘッダー */}
+        <div className="detail-header">
+          <button className="back-btn" onClick={() => setSelectedScore(null)}>
+            ← 一覧へ戻る
+          </button>
+          <div className="detail-title-area">
+            <h2 className="detail-test-name">{selectedScore.testName}</h2>
+            <span className="detail-test-date">{selectedScore.testDate}</span>
+            {selectedScore.fourSubjects?.deviation && (
+              <span className="detail-deviation-badge">
+                4科偏差値 {selectedScore.fourSubjects.deviation}
+              </span>
+            )}
+          </div>
+          <div className="detail-header-actions">
+            <button className="btn-edit-score" onClick={() => handleEditScore(selectedScore)}>
+              ✏️ 成績編集
+            </button>
+          </div>
+        </div>
+
+        {/* アクションバー */}
+        <div className="action-bar">
+          <div className="action-bar-info">
+            <span className="problem-count-badge">
+              記録済み問題: {problemLogs.length}問
+            </span>
+            {revengeList.length > 0 && (
+              <span className="revenge-count-badge">
+                リベンジ対象: {revengeList.length}問
+              </span>
+            )}
+          </div>
+          <div className="action-bar-buttons">
+            <button
+              className="btn-sync-units"
+              onClick={handleSyncToMasterUnits}
+              disabled={syncingUnits}
+            >
+              {syncingUnits ? '反映中...' : '🔴 マスター単元へ反映'}
+            </button>
+            <button
+              className="btn-create-tasks"
+              onClick={handleCreateRevengeTasks}
+              disabled={creatingTasks || revengeList.length === 0}
+            >
+              {creatingTasks ? '作成中...' : `📅 解き直しタスクを作成 (${revengeList.length}問)`}
+            </button>
+          </div>
+        </div>
+
+        {/* ============ 問題別記録 ============ */}
+        <div className="section-card">
+          <div className="section-header">
+            <h3 className="section-title">問題別記録</h3>
+            <button
+              className="btn-add-problem"
+              onClick={() => { setProblemForm(getEmptyProblemForm()); setShowProblemForm(true) }}
+            >
+              ＋ 問題を追加
+            </button>
+          </div>
+
+          {problemLogs.length === 0 ? (
+            <div className="empty-problems">
+              問題を追加して、正答率・単元・正誤を記録しましょう
+            </div>
+          ) : (
+            <div className="problem-table-wrapper">
+              <table className="problem-table">
+                <thead>
+                  <tr>
+                    <th>#</th>
+                    <th>教科</th>
+                    <th>単元</th>
+                    <th>正答率</th>
+                    <th>正誤</th>
+                    <th>解き直し</th>
+                    <th>教材リンク</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {problemLogs
+                    .slice()
+                    .sort((a, b) => a.problemNumber - b.problemNumber)
+                    .map(problem => {
+                      const linked = getLinkedTexts(problem)
+                      const { label, color, bg } = reviewStatusLabel(problem.reviewStatus)
+                      const correctRateNum = parseFloat(problem.correctRate)
+                      const isRevenge = !problem.isCorrect && correctRateNum >= 50
+                      return (
+                        <tr
+                          key={problem.id}
+                          className={`problem-row ${!problem.isCorrect ? 'wrong-row' : ''} ${isRevenge ? 'revenge-row' : ''}`}
+                        >
+                          <td className="cell-num">
+                            {problem.problemNumber}
+                            {isRevenge && <span className="revenge-marker" title="リベンジ対象">⚡</span>}
+                          </td>
+                          <td className="cell-subject">
+                            <span className={`subject-chip subject-${problem.subject}`}>
+                              {problem.subject}
+                            </span>
+                          </td>
+                          <td className="cell-units">
+                            {problem.unitIds?.length > 0
+                              ? problem.unitIds.map(id => (
+                                <span key={id} className="unit-tag">{getUnitName(id)}</span>
+                              ))
+                              : <span className="no-unit">–</span>
+                            }
+                          </td>
+                          <td className="cell-rate">
+                            <span
+                              className="correct-rate-badge"
+                              style={{
+                                background: correctRateNum >= 70 ? '#dcfce7' : correctRateNum >= 40 ? '#fef9c3' : '#fee2e2',
+                                color: correctRateNum >= 70 ? '#16a34a' : correctRateNum >= 40 ? '#ca8a04' : '#dc2626',
+                              }}
+                            >
+                              {problem.correctRate}%
+                            </span>
+                          </td>
+                          <td className="cell-correct">
+                            {problem.isCorrect
+                              ? <span className="correct-mark">○</span>
+                              : <span className="wrong-mark">✗</span>
+                            }
+                          </td>
+                          <td className="cell-status">
+                            <select
+                              className="status-select"
+                              value={problem.reviewStatus || 'pending'}
+                              style={{ background: bg, color: color }}
+                              onChange={(e) => handleUpdateProblemStatus(problem.id, e.target.value)}
+                            >
+                              <option value="pending">未完了</option>
+                              <option value="done">解き直し済</option>
+                              <option value="retry">要再挑戦</option>
+                            </select>
+                          </td>
+                          <td className="cell-links">
+                            {linked.length > 0
+                              ? linked.map(text => (
+                                <a
+                                  key={text.firestoreId || text.id}
+                                  href={text.fileUrl}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="sapix-text-link"
+                                  title={text.textName}
+                                >
+                                  📄 {text.textNumber || text.textName}
+                                </a>
+                              ))
+                              : <span className="no-link">–</span>
+                            }
+                          </td>
+                          <td className="cell-delete">
+                            <button
+                              className="btn-delete-problem"
+                              onClick={() => handleDeleteProblem(problem.id)}
+                              title="削除"
+                            >
+                              ×
+                            </button>
+                          </td>
+                        </tr>
+                      )
+                    })
+                  }
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+
+        {/* ============ リベンジリスト ============ */}
+        <div className="section-card revenge-section">
+          <div className="section-header">
+            <h3 className="section-title">
+              ⚡ リベンジリスト
+              <span className="revenge-subtitle">正答率 50%以上なのに失点した問題</span>
+            </h3>
+          </div>
+
+          {revengeList.length === 0 ? (
+            <div className="empty-problems">
+              リベンジ対象の問題はありません（問題を追加してください）
+            </div>
+          ) : (
+            <div className="revenge-list">
+              {revengeList.map((problem, idx) => {
+                const linked = getLinkedTexts(problem)
+                const unitNames = problem.unitIds?.map(id => getUnitName(id)).join('・') || '単元なし'
+                return (
+                  <div key={problem.id} className="revenge-item">
+                    <div className="revenge-rank">#{idx + 1}</div>
+                    <div className="revenge-info">
+                      <div className="revenge-title">
+                        第{problem.problemNumber}問
+                        <span className={`subject-chip subject-${problem.subject}`}>{problem.subject}</span>
+                      </div>
+                      <div className="revenge-meta">
+                        <span className="revenge-rate">
+                          正答率 <strong>{problem.correctRate}%</strong>
+                        </span>
+                        <span className="revenge-units">{unitNames}</span>
+                      </div>
+                      {linked.length > 0 && (
+                        <div className="revenge-links">
+                          {linked.map(text => (
+                            <a
+                              key={text.firestoreId || text.id}
+                              href={text.fileUrl}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="sapix-text-link"
+                            >
+                              📄 {text.textNumber || text.textName}
+                            </a>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                    <div className="revenge-status">
+                      <select
+                        className="status-select"
+                        value={problem.reviewStatus || 'pending'}
+                        onChange={(e) => handleUpdateProblemStatus(problem.id, e.target.value)}
+                      >
+                        <option value="pending">未完了</option>
+                        <option value="done">解き直し済</option>
+                        <option value="retry">要再挑戦</option>
+                      </select>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* ============ 問題追加フォーム（モーダル）============ */}
+        {showProblemForm && (
+          <div className="form-overlay" onClick={() => setShowProblemForm(false)}>
+            <div className="form-container problem-form-container" onClick={e => e.stopPropagation()}>
+              <h3>問題を追加</h3>
+
+              <div className="form-row">
+                <div className="form-field">
+                  <label>教科</label>
+                  <select
+                    value={problemForm.subject}
+                    onChange={(e) => setProblemForm({ ...problemForm, subject: e.target.value, unitIds: [] })}
+                  >
+                    {SUBJECTS.map(s => <option key={s} value={s}>{s}</option>)}
+                  </select>
+                </div>
+                <div className="form-field">
+                  <label>問題番号 *</label>
+                  <input
+                    type="number"
+                    min="1"
+                    placeholder="例: 5"
+                    value={problemForm.problemNumber}
+                    onChange={(e) => setProblemForm({ ...problemForm, problemNumber: e.target.value })}
+                  />
+                </div>
+                <div className="form-field">
+                  <label>配点（任意）</label>
+                  <input
+                    type="number"
+                    min="0"
+                    placeholder="例: 6"
+                    value={problemForm.points}
+                    onChange={(e) => setProblemForm({ ...problemForm, points: e.target.value })}
+                  />
+                </div>
+              </div>
+
+              <div className="form-row">
+                <div className="form-field">
+                  <label>全体正答率（%）</label>
+                  <input
+                    type="number"
+                    min="0"
+                    max="100"
+                    placeholder="例: 72"
+                    value={problemForm.correctRate}
+                    onChange={(e) => setProblemForm({ ...problemForm, correctRate: e.target.value })}
+                  />
+                </div>
+                <div className="form-field">
+                  <label>ハルキの正誤</label>
+                  <div className="correct-radio-group">
+                    <label className={`radio-btn ${problemForm.isCorrect ? 'radio-correct active' : 'radio-correct'}`}>
+                      <input
+                        type="radio"
+                        checked={problemForm.isCorrect === true}
+                        onChange={() => setProblemForm({ ...problemForm, isCorrect: true })}
+                      />
+                      ○ 正解
+                    </label>
+                    <label className={`radio-btn ${!problemForm.isCorrect ? 'radio-wrong active' : 'radio-wrong'}`}>
+                      <input
+                        type="radio"
+                        checked={problemForm.isCorrect === false}
+                        onChange={() => setProblemForm({ ...problemForm, isCorrect: false })}
+                      />
+                      ✗ 不正解
+                    </label>
+                  </div>
+                </div>
+              </div>
+
+              {/* 単元タグ選択 */}
+              {unitsForSubject.length > 0 && (
+                <div className="form-field">
+                  <label>単元タグ（複数選択可）</label>
+                  <div className="unit-checkbox-grid">
+                    {unitsForSubject.map(unit => (
+                      <label key={unit.id} className={`unit-checkbox-label ${problemForm.unitIds.includes(unit.id) ? 'checked' : ''}`}>
+                        <input
+                          type="checkbox"
+                          checked={problemForm.unitIds.includes(unit.id)}
+                          onChange={(e) => {
+                            const newIds = e.target.checked
+                              ? [...problemForm.unitIds, unit.id]
+                              : problemForm.unitIds.filter(id => id !== unit.id)
+                            setProblemForm({ ...problemForm, unitIds: newIds })
+                          }}
+                        />
+                        <span>{unit.name}</span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              <div className="form-actions">
+                <button className="btn-secondary" onClick={() => setShowProblemForm(false)}>
+                  キャンセル
+                </button>
+                <button className="btn-primary" onClick={handleSaveProblem}>
+                  追加
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* 成績編集フォーム */}
+        {showForm && renderScoreForm()}
+      </div>
+    )
+  }
+
+  // ============================================================
+  // RENDER - サマリービュー（一覧）
+  // ============================================================
+
+  function renderScoreForm() {
+    return (
+      <div className="form-overlay" onClick={() => setShowForm(false)}>
+        <div className="form-container" onClick={(e) => e.stopPropagation()}>
+          <h3>{editingScore ? '✏️ 成績を編集' : '➕ 成績を追加'}</h3>
+
+          <div className="form-section">
+            <h4>基本情報</h4>
+            <div className="form-row">
+              <div className="form-field">
+                <label>テスト名 *</label>
+                <select
+                  value={scoreForm.testName}
+                  onChange={(e) => setScoreForm({ ...scoreForm, testName: e.target.value })}
+                >
+                  <option value="">選択してください</option>
+                  {testTypes.map(type => (
+                    <option key={type} value={type}>{type}</option>
+                  ))}
+                </select>
+              </div>
+              <div className="form-field">
+                <label>実施日 *</label>
+                <input
+                  type="date"
+                  value={scoreForm.testDate}
+                  onChange={(e) => setScoreForm({ ...scoreForm, testDate: e.target.value })}
+                />
+              </div>
+              <div className="form-field">
+                <label>学年</label>
+                <select
+                  value={scoreForm.grade}
+                  onChange={(e) => setScoreForm({ ...scoreForm, grade: e.target.value })}
+                >
+                  {grades.map(g => (
+                    <option key={g} value={g}>{g}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+          </div>
+
+          <div className="form-section">
+            <h4>科目別得点</h4>
+            {[
+              { key: 'kokugo', label: '国語' },
+              { key: 'sansu', label: '算数' },
+              { key: 'rika', label: '理科' },
+              { key: 'shakai', label: '社会' }
+            ].map(({ key, label }) => (
+              <div key={key} className="form-row subject-row">
+                <div className="form-field">
+                  <label>{label}</label>
+                  <div className="score-input-group">
+                    <input
+                      type="number"
+                      placeholder="得点"
+                      value={scoreForm.scores[key]}
+                      onChange={(e) => setScoreForm({
+                        ...scoreForm,
+                        scores: { ...scoreForm.scores, [key]: e.target.value }
+                      })}
+                    />
+                    <span>/</span>
+                    <input
+                      type="number"
+                      placeholder="満点"
+                      value={scoreForm.maxScores[key]}
+                      onChange={(e) => setScoreForm({
+                        ...scoreForm,
+                        maxScores: { ...scoreForm.maxScores, [key]: e.target.value }
+                      })}
+                    />
+                  </div>
+                </div>
+                <div className="form-field">
+                  <label>偏差値</label>
+                  <input
+                    type="number"
+                    step="0.1"
+                    placeholder="偏差値"
+                    value={scoreForm.deviations[key]}
+                    onChange={(e) => setScoreForm({
+                      ...scoreForm,
+                      deviations: { ...scoreForm.deviations, [key]: e.target.value }
+                    })}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="form-section">
+            <h4>2科目（国語+算数）</h4>
+            <div className="form-row summary-row">
+              <div className="form-field">
+                <label>得点</label>
+                <div className="score-input-group">
+                  <input
+                    type="number" placeholder="得点"
+                    value={scoreForm.twoSubjects.score}
+                    onChange={(e) => setScoreForm({ ...scoreForm, twoSubjects: { ...scoreForm.twoSubjects, score: e.target.value } })}
+                  />
+                  <span>/</span>
+                  <input
+                    type="number" placeholder="満点"
+                    value={scoreForm.twoSubjects.maxScore}
+                    onChange={(e) => setScoreForm({ ...scoreForm, twoSubjects: { ...scoreForm.twoSubjects, maxScore: e.target.value } })}
+                  />
+                </div>
+              </div>
+              <div className="form-field">
+                <label>偏差値</label>
+                <input
+                  type="number" step="0.1" placeholder="偏差値"
+                  value={scoreForm.twoSubjects.deviation}
+                  onChange={(e) => setScoreForm({ ...scoreForm, twoSubjects: { ...scoreForm.twoSubjects, deviation: e.target.value } })}
+                />
+              </div>
+              <div className="form-field">
+                <label>順位</label>
+                <div className="score-input-group">
+                  <input
+                    type="number" placeholder="順位"
+                    value={scoreForm.twoSubjects.rank}
+                    onChange={(e) => setScoreForm({ ...scoreForm, twoSubjects: { ...scoreForm.twoSubjects, rank: e.target.value } })}
+                  />
+                  <span>/</span>
+                  <input
+                    type="number" placeholder="受験者数"
+                    value={scoreForm.twoSubjects.totalStudents}
+                    onChange={(e) => setScoreForm({ ...scoreForm, twoSubjects: { ...scoreForm.twoSubjects, totalStudents: e.target.value } })}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="form-section">
+            <h4>4科目合計</h4>
+            <div className="form-row summary-row">
+              <div className="form-field">
+                <label>得点</label>
+                <div className="score-input-group">
+                  <input
+                    type="number" placeholder="得点"
+                    value={scoreForm.fourSubjects.score}
+                    onChange={(e) => setScoreForm({ ...scoreForm, fourSubjects: { ...scoreForm.fourSubjects, score: e.target.value } })}
+                  />
+                  <span>/</span>
+                  <input
+                    type="number" placeholder="満点"
+                    value={scoreForm.fourSubjects.maxScore}
+                    onChange={(e) => setScoreForm({ ...scoreForm, fourSubjects: { ...scoreForm.fourSubjects, maxScore: e.target.value } })}
+                  />
+                </div>
+              </div>
+              <div className="form-field">
+                <label>偏差値</label>
+                <input
+                  type="number" step="0.1" placeholder="偏差値"
+                  value={scoreForm.fourSubjects.deviation}
+                  onChange={(e) => setScoreForm({ ...scoreForm, fourSubjects: { ...scoreForm.fourSubjects, deviation: e.target.value } })}
+                />
+              </div>
+              <div className="form-field">
+                <label>順位</label>
+                <div className="score-input-group">
+                  <input
+                    type="number" placeholder="順位"
+                    value={scoreForm.fourSubjects.rank}
+                    onChange={(e) => setScoreForm({ ...scoreForm, fourSubjects: { ...scoreForm.fourSubjects, rank: e.target.value } })}
+                  />
+                  <span>/</span>
+                  <input
+                    type="number" placeholder="受験者数"
+                    value={scoreForm.fourSubjects.totalStudents}
+                    onChange={(e) => setScoreForm({ ...scoreForm, fourSubjects: { ...scoreForm.fourSubjects, totalStudents: e.target.value } })}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="form-section">
+            <h4>その他</h4>
+            <div className="form-row">
+              <div className="form-field">
+                <label>コース</label>
+                <input
+                  type="text" placeholder="例: α1"
+                  value={scoreForm.course}
+                  onChange={(e) => setScoreForm({ ...scoreForm, course: e.target.value })}
+                />
+              </div>
+              <div className="form-field">
+                <label>クラス</label>
+                <input
+                  type="text" placeholder="例: A組"
+                  value={scoreForm.className}
+                  onChange={(e) => setScoreForm({ ...scoreForm, className: e.target.value })}
+                />
+              </div>
+            </div>
+            <div className="form-field full">
+              <label>メモ</label>
+              <textarea
+                rows="3"
+                placeholder="反省点、次回の目標など..."
+                value={scoreForm.notes}
+                onChange={(e) => setScoreForm({ ...scoreForm, notes: e.target.value })}
+              />
+            </div>
+          </div>
+
+          <div className="form-actions">
+            <button className="btn-secondary" onClick={() => setShowForm(false)}>
+              キャンセル
+            </button>
+            <button className="btn-primary" onClick={handleSave}>
+              {editingScore ? '✓ 更新' : '✓ 保存'}
+            </button>
+          </div>
+        </div>
+      </div>
+    )
   }
 
   return (
     <div className="testscore-view">
-      {/* ヘッダー - ダッシュボードと統一 */}
+      {/* ヘッダー */}
       <div className="dashboard-header">
         <div className="selection-area">
           <label>学年:</label>
@@ -157,7 +974,7 @@ function TestScoreView({ user }) {
         <DeviationChart data={chartData} />
       )}
 
-      {/* 成績カード一覧 */}
+      {/* 成績カード一覧（クリックで詳細へ） */}
       <div className="scores-content">
         {filteredScores.length === 0 ? (
           <div className="no-data">
@@ -167,294 +984,26 @@ function TestScoreView({ user }) {
         ) : (
           <div className="scores-list">
             {filteredScores.map(score => (
-              <ScoreCard
-                key={score.firestoreId}
-                score={score}
-                onEdit={handleEditScore}
-                onDelete={handleDelete}
-              />
+              <div key={score.firestoreId} className="score-card-wrapper">
+                <ScoreCard
+                  score={score}
+                  onEdit={handleEditScore}
+                  onDelete={handleDelete}
+                />
+                <button
+                  className="btn-open-detail"
+                  onClick={() => handleOpenDetail(score)}
+                >
+                  問題別分析・リベンジリスト →
+                </button>
+              </div>
             ))}
           </div>
         )}
       </div>
 
       {/* 成績入力フォーム */}
-      {showForm && (
-        <div className="form-overlay" onClick={() => setShowForm(false)}>
-          <div className="form-container" onClick={(e) => e.stopPropagation()}>
-            <h3>{editingScore ? '✏️ 成績を編集' : '➕ 成績を追加'}</h3>
-
-            <div className="form-section">
-              <h4>基本情報</h4>
-              <div className="form-row">
-                <div className="form-field">
-                  <label>テスト名 *</label>
-                  <select
-                    value={scoreForm.testName}
-                    onChange={(e) => setScoreForm({ ...scoreForm, testName: e.target.value })}
-                  >
-                    <option value="">選択してください</option>
-                    {testTypes.map(type => (
-                      <option key={type} value={type}>{type}</option>
-                    ))}
-                  </select>
-                </div>
-                <div className="form-field">
-                  <label>実施日 *</label>
-                  <input
-                    type="date"
-                    value={scoreForm.testDate}
-                    onChange={(e) => setScoreForm({ ...scoreForm, testDate: e.target.value })}
-                  />
-                </div>
-                <div className="form-field">
-                  <label>学年</label>
-                  <select
-                    value={scoreForm.grade}
-                    onChange={(e) => setScoreForm({ ...scoreForm, grade: e.target.value })}
-                  >
-                    {grades.map(g => (
-                      <option key={g} value={g}>{g}</option>
-                    ))}
-                  </select>
-                </div>
-              </div>
-            </div>
-
-            <div className="form-section">
-              <h4>科目別得点</h4>
-              {[
-                { key: 'kokugo', label: '国語' },
-                { key: 'sansu', label: '算数' },
-                { key: 'rika', label: '理科' },
-                { key: 'shakai', label: '社会' }
-              ].map(({ key, label }) => (
-                <div key={key} className="form-row subject-row">
-                  <div className="form-field">
-                    <label>{label}</label>
-                    <div className="score-input-group">
-                      <input
-                        type="number"
-                        placeholder="得点"
-                        value={scoreForm.scores[key]}
-                        onChange={(e) => setScoreForm({
-                          ...scoreForm,
-                          scores: { ...scoreForm.scores, [key]: e.target.value }
-                        })}
-                      />
-                      <span>/</span>
-                      <input
-                        type="number"
-                        placeholder="満点"
-                        value={scoreForm.maxScores[key]}
-                        onChange={(e) => setScoreForm({
-                          ...scoreForm,
-                          maxScores: { ...scoreForm.maxScores, [key]: e.target.value }
-                        })}
-                      />
-                    </div>
-                  </div>
-                  <div className="form-field">
-                    <label>偏差値</label>
-                    <input
-                      type="number"
-                      step="0.1"
-                      placeholder="偏差値"
-                      value={scoreForm.deviations[key]}
-                      onChange={(e) => setScoreForm({
-                        ...scoreForm,
-                        deviations: { ...scoreForm.deviations, [key]: e.target.value }
-                      })}
-                    />
-                  </div>
-                </div>
-              ))}
-            </div>
-
-            <div className="form-section">
-              <h4>2科目（国語+算数）</h4>
-              <div className="form-row summary-row">
-                <div className="form-field">
-                  <label>得点</label>
-                  <div className="score-input-group">
-                    <input
-                      type="number"
-                      placeholder="得点"
-                      value={scoreForm.twoSubjects.score}
-                      onChange={(e) => setScoreForm({
-                        ...scoreForm,
-                        twoSubjects: { ...scoreForm.twoSubjects, score: e.target.value }
-                      })}
-                    />
-                    <span>/</span>
-                    <input
-                      type="number"
-                      placeholder="満点"
-                      value={scoreForm.twoSubjects.maxScore}
-                      onChange={(e) => setScoreForm({
-                        ...scoreForm,
-                        twoSubjects: { ...scoreForm.twoSubjects, maxScore: e.target.value }
-                      })}
-                    />
-                  </div>
-                </div>
-                <div className="form-field">
-                  <label>偏差値</label>
-                  <input
-                    type="number"
-                    step="0.1"
-                    placeholder="偏差値"
-                    value={scoreForm.twoSubjects.deviation}
-                    onChange={(e) => setScoreForm({
-                      ...scoreForm,
-                      twoSubjects: { ...scoreForm.twoSubjects, deviation: e.target.value }
-                    })}
-                  />
-                </div>
-                <div className="form-field">
-                  <label>順位</label>
-                  <div className="score-input-group">
-                    <input
-                      type="number"
-                      placeholder="順位"
-                      value={scoreForm.twoSubjects.rank}
-                      onChange={(e) => setScoreForm({
-                        ...scoreForm,
-                        twoSubjects: { ...scoreForm.twoSubjects, rank: e.target.value }
-                      })}
-                    />
-                    <span>/</span>
-                    <input
-                      type="number"
-                      placeholder="受験者数"
-                      value={scoreForm.twoSubjects.totalStudents}
-                      onChange={(e) => setScoreForm({
-                        ...scoreForm,
-                        twoSubjects: { ...scoreForm.twoSubjects, totalStudents: e.target.value }
-                      })}
-                    />
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <div className="form-section">
-              <h4>4科目合計</h4>
-              <div className="form-row summary-row">
-                <div className="form-field">
-                  <label>得点</label>
-                  <div className="score-input-group">
-                    <input
-                      type="number"
-                      placeholder="得点"
-                      value={scoreForm.fourSubjects.score}
-                      onChange={(e) => setScoreForm({
-                        ...scoreForm,
-                        fourSubjects: { ...scoreForm.fourSubjects, score: e.target.value }
-                      })}
-                    />
-                    <span>/</span>
-                    <input
-                      type="number"
-                      placeholder="満点"
-                      value={scoreForm.fourSubjects.maxScore}
-                      onChange={(e) => setScoreForm({
-                        ...scoreForm,
-                        fourSubjects: { ...scoreForm.fourSubjects, maxScore: e.target.value }
-                      })}
-                    />
-                  </div>
-                </div>
-                <div className="form-field">
-                  <label>偏差値</label>
-                  <input
-                    type="number"
-                    step="0.1"
-                    placeholder="偏差値"
-                    value={scoreForm.fourSubjects.deviation}
-                    onChange={(e) => setScoreForm({
-                      ...scoreForm,
-                      fourSubjects: { ...scoreForm.fourSubjects, deviation: e.target.value }
-                    })}
-                  />
-                </div>
-                <div className="form-field">
-                  <label>順位</label>
-                  <div className="score-input-group">
-                    <input
-                      type="number"
-                      placeholder="順位"
-                      value={scoreForm.fourSubjects.rank}
-                      onChange={(e) => setScoreForm({
-                        ...scoreForm,
-                        fourSubjects: { ...scoreForm.fourSubjects, rank: e.target.value }
-                      })}
-                    />
-                    <span>/</span>
-                    <input
-                      type="number"
-                      placeholder="受験者数"
-                      value={scoreForm.fourSubjects.totalStudents}
-                      onChange={(e) => setScoreForm({
-                        ...scoreForm,
-                        fourSubjects: { ...scoreForm.fourSubjects, totalStudents: e.target.value }
-                      })}
-                    />
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <div className="form-section">
-              <h4>その他</h4>
-              <div className="form-row">
-                <div className="form-field">
-                  <label>コース</label>
-                  <input
-                    type="text"
-                    placeholder="例: α1"
-                    value={scoreForm.course}
-                    onChange={(e) => setScoreForm({ ...scoreForm, course: e.target.value })}
-                  />
-                </div>
-                <div className="form-field">
-                  <label>クラス</label>
-                  <input
-                    type="text"
-                    placeholder="例: A組"
-                    value={scoreForm.className}
-                    onChange={(e) => setScoreForm({ ...scoreForm, className: e.target.value })}
-                  />
-                </div>
-              </div>
-              <div className="form-field full">
-                <label>メモ</label>
-                <textarea
-                  rows="3"
-                  placeholder="反省点、次回の目標など..."
-                  value={scoreForm.notes}
-                  onChange={(e) => setScoreForm({ ...scoreForm, notes: e.target.value })}
-                />
-              </div>
-            </div>
-
-            <div className="form-actions">
-              <button
-                className="btn-secondary"
-                onClick={() => setShowForm(false)}
-              >
-                キャンセル
-              </button>
-              <button
-                className="btn-primary"
-                onClick={handleSave}
-              >
-                {editingScore ? '✓ 更新' : '✓ 保存'}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      {showForm && renderScoreForm()}
     </div>
   )
 }


### PR DESCRIPTION
…evenge list

- Add per-problem recording: subject, problem number, correct rate, isCorrect flag, and master unit tags
- Auto-generate "Revenge List" (正答率 >= 50% && wrong answers), sorted by correct rate descending
- "マスター単元へ反映" button: writes red lessonLog for each wrong problem with unit tags, updating proficiency automatically
- "解き直しタスクを作成" button: creates A-priority schedule tasks for revenge items, due next week
- PDF link column: links problems to SAPIX text materials by unit ID
- Problem status tracking: pending / done / retry via inline select
- Score cards now have "問題別分析・リベンジリスト →" detail button

https://claude.ai/code/session_01TdzUBCnxia3ienbEbhZLfs