### PR TITLE
マスター単元を4教科200単元体制に拡張

### DIFF
--- a/child-learning-app/src/utils/importMasterUnits.js
+++ b/child-learning-app/src/utils/importMasterUnits.js
@@ -1,165 +1,99 @@
 /**
- * クライアント側から単元マスタをインポートするユーティリティ
- * iPhoneのブラウザから実行可能
+ * マスター単元 管理モジュール
+ *
+ * 教科別データは src/utils/masterUnits/ 以下で管理。
+ * 単元の追加・変更は各教科ファイルを直接編集してください。
+ *   算数: masterUnits/sansu.js
+ *   国語: masterUnits/kokugo.js
+ *   理科: masterUnits/rika.js
+ *   社会: masterUnits/shakai.js
  */
 
 import { collection, doc, setDoc, getDocs, serverTimestamp } from 'firebase/firestore'
 import { db } from '../firebase'
+import { SANSU_UNITS } from './masterUnits/sansu'
+import { KOKUGO_UNITS } from './masterUnits/kokugo'
+import { RIKA_UNITS } from './masterUnits/rika'
+import { SHAKAI_UNITS } from './masterUnits/shakai'
 
-// 単元マスタ初期データ（50単元）- アプリ内のフォールバック静的データとしても使用
+// 教科ラベルの定義（表示名とIDプレフィックスの対応）
+export const SUBJECTS = {
+  算数: { label: '算数', color: '#3b82f6' },
+  国語: { label: '国語', color: '#ec4899' },
+  理科: { label: '理科', color: '#10b981' },
+  社会: { label: '社会', color: '#f59e0b' },
+}
+
+// 全教科データ（subject フィールドを付与して統合）
 export const MASTER_UNITS_DATA = [
-  // 計算 (4)
-  { id: 'CALC_BASIC', name: '四則計算の基礎', category: '計算', difficulty_level: 1, order_index: 10 },
-  { id: 'CALC_TRICK', name: '計算のくふう', category: '計算', difficulty_level: 2, order_index: 20 },
-  { id: 'CALC_UNIT', name: '単位換算', category: '計算', difficulty_level: 2, order_index: 30 },
-  { id: 'CALC_BOX', name: '□を求める計算', category: '計算', difficulty_level: 2, order_index: 40 },
-
-  // 数の性質 (1)
-  { id: 'NUM_DIVISOR', name: '約数・倍数', category: '数の性質', difficulty_level: 3, order_index: 50 },
-
-  // 規則性 (4)
-  { id: 'PATTERN_SEQ', name: '規則性(数列)', category: '規則性', difficulty_level: 3, order_index: 60 },
-  { id: 'PATTERN_TABLE', name: '数表', category: '規則性', difficulty_level: 3, order_index: 70 },
-  { id: 'PATTERN_CALENDAR', name: '日暦算', category: '規則性', difficulty_level: 2, order_index: 80 },
-  { id: 'PATTERN_CYCLE', name: '周期算', category: '規則性', difficulty_level: 3, order_index: 90 },
-
-  // 特殊算 (15)
-  { id: 'SPEC_WACHA', name: '和差算', category: '特殊算', difficulty_level: 2, order_index: 100 },
-  { id: 'SPEC_AGE', name: '年齢算', category: '特殊算', difficulty_level: 2, order_index: 110 },
-  { id: 'SPEC_TSURU', name: 'つるかめ算', category: '特殊算', difficulty_level: 3, order_index: 120 },
-  { id: 'SPEC_DIFF', name: '差集め算', category: '特殊算', difficulty_level: 3, order_index: 130 },
-  { id: 'SPEC_EXCESS', name: '過不足算', category: '特殊算', difficulty_level: 3, order_index: 140 },
-  { id: 'SPEC_TREE', name: '植木算', category: '特殊算', difficulty_level: 2, order_index: 150 },
-  { id: 'SPEC_SQUARE', name: '方陣算', category: '特殊算', difficulty_level: 3, order_index: 160 },
-  { id: 'SPEC_DISTRIB', name: '分配算', category: '特殊算', difficulty_level: 3, order_index: 170 },
-  { id: 'SPEC_EQUIV', name: '相当算', category: '特殊算', difficulty_level: 3, order_index: 180 },
-  { id: 'SPEC_RESTORE', name: '還元算', category: '特殊算', difficulty_level: 3, order_index: 190 },
-  { id: 'SPEC_MULTIPLE', name: '倍数算', category: '特殊算', difficulty_level: 3, order_index: 200 },
-  { id: 'SPEC_ELIM', name: '消去算', category: '特殊算', difficulty_level: 4, order_index: 210 },
-  { id: 'SPEC_AVG', name: '平均算', category: '特殊算', difficulty_level: 2, order_index: 220 },
-  { id: 'SPEC_WORK', name: '仕事算', category: '特殊算', difficulty_level: 4, order_index: 230 },
-  { id: 'SPEC_NEWTON', name: 'ニュートン算', category: '特殊算', difficulty_level: 5, order_index: 240 },
-
-  // 速さ (5)
-  { id: 'SPEED_BASIC', name: '速さの基本', category: '速さ', difficulty_level: 2, order_index: 250 },
-  { id: 'SPEED_TRAVEL', name: '旅人算', category: '速さ', difficulty_level: 3, order_index: 260 },
-  { id: 'SPEED_PASS', name: '通過算', category: '速さ', difficulty_level: 3, order_index: 270 },
-  { id: 'SPEED_RIVER', name: '流水算', category: '速さ', difficulty_level: 3, order_index: 280 },
-  { id: 'SPEED_CLOCK', name: '時計算', category: '速さ', difficulty_level: 4, order_index: 290 },
-
-  // 割合 (3)
-  { id: 'RATIO_BASIC', name: '割合の基本', category: '割合', difficulty_level: 2, order_index: 300 },
-  { id: 'RATIO_PROFIT', name: '売買損益', category: '割合', difficulty_level: 3, order_index: 310 },
-  { id: 'RATIO_CONC', name: '食塩水', category: '割合', difficulty_level: 4, order_index: 320 },
-
-  // 比 (3)
-  { id: 'PROP_BASIC', name: '比の基本', category: '比', difficulty_level: 3, order_index: 330 },
-  { id: 'PROP_RATIO', name: '比例・反比例', category: '比', difficulty_level: 3, order_index: 340 },
-  { id: 'PROP_SPEED', name: '速さと比', category: '比', difficulty_level: 4, order_index: 350 },
-
-  // 平面図形 (7)
-  { id: 'PLANE_ANGLE', name: '角度', category: '平面図形', difficulty_level: 2, order_index: 360 },
-  { id: 'PLANE_AREA', name: '面積', category: '平面図形', difficulty_level: 2, order_index: 370 },
-  { id: 'PLANE_CIRCLE', name: '円・おうぎ形', category: '平面図形', difficulty_level: 3, order_index: 380 },
-  { id: 'PLANE_EQUIV', name: '等積変形', category: '平面図形', difficulty_level: 4, order_index: 390 },
-  { id: 'PLANE_MOVE', name: '図形の移動', category: '平面図形', difficulty_level: 3, order_index: 400 },
-  { id: 'PLANE_SIMILAR', name: '相似', category: '平面図形', difficulty_level: 4, order_index: 410 },
-  { id: 'PLANE_RATIO', name: '面積比・線分比', category: '平面図形', difficulty_level: 5, order_index: 420 },
-
-  // 立体図形 (5)
-  { id: 'SOLID_BASIC', name: '立体の名前・展開図', category: '立体図形', difficulty_level: 2, order_index: 430 },
-  { id: 'SOLID_VOLUME', name: '体積・表面積', category: '立体図形', difficulty_level: 3, order_index: 440 },
-  { id: 'SOLID_CUT', name: '立体の切断', category: '立体図形', difficulty_level: 5, order_index: 450 },
-  { id: 'SOLID_ROTATE', name: '回転体', category: '立体図形', difficulty_level: 4, order_index: 460 },
-  { id: 'SOLID_WATER', name: '水位の変化', category: '立体図形', difficulty_level: 4, order_index: 470 },
-
-  // 場合の数 (1)
-  { id: 'COMB_COUNT', name: '場合の数', category: '場合の数', difficulty_level: 4, order_index: 480 },
-
-  // グラフ・論理 (2)
-  { id: 'LOGIC_GRAPH', name: 'グラフ', category: 'グラフ・論理', difficulty_level: 3, order_index: 490 },
-  { id: 'LOGIC_COND', name: '条件整理・論理', category: 'グラフ・論理', difficulty_level: 4, order_index: 500 }
+  ...SANSU_UNITS.map(u => ({ ...u, subject: '算数' })),
+  ...KOKUGO_UNITS.map(u => ({ ...u, subject: '国語' })),
+  ...RIKA_UNITS.map(u => ({ ...u, subject: '理科' })),
+  ...SHAKAI_UNITS.map(u => ({ ...u, subject: '社会' })),
 ]
 
 /**
- * Firestoreに単元マスタをインポート
- * @param {Function} onProgress - 進捗コールバック (current, total, message)
- * @returns {Promise<{success: number, failed: number, errors: Array}>}
+ * 静的な単元データを返す（オフライン・フォールバック用）
+ * @param {string|null} subject - 絞り込む教科名。null の場合は全教科
+ * @returns {Array}
  */
-export async function importMasterUnitsToFirestore(onProgress = null) {
-  const results = {
-    success: 0,
-    failed: 0,
-    errors: []
-  }
-
-  const total = MASTER_UNITS_DATA.length
-
-  for (let i = 0; i < MASTER_UNITS_DATA.length; i++) {
-    const unit = MASTER_UNITS_DATA[i]
-
-    try {
-      if (onProgress) {
-        onProgress(i + 1, total, `インポート中: ${unit.name}`)
-      }
-
-      const docRef = doc(db, 'masterUnits', unit.id)
-
-      // snake_case → camelCase 変換
-      const firestoreData = {
-        id: unit.id,
-        name: unit.name,
-        subject: unit.subject || '算数',
-        category: unit.category,
-        difficultyLevel: unit.difficulty_level || null,
-        description: unit.description || '',
-        learningResources: unit.learning_resources || [],
-        orderIndex: unit.order_index || 0,
-        isActive: unit.is_active !== false,
-        createdAt: serverTimestamp(),
-        updatedAt: serverTimestamp()
-      }
-
-      await setDoc(docRef, firestoreData)
-      results.success++
-    } catch (error) {
-      console.error(`エラー: ${unit.id}`, error)
-      results.failed++
-      results.errors.push({
-        id: unit.id,
-        name: unit.name,
-        error: error.message
-      })
-    }
-  }
-
-  return results
-}
-
-/**
- * 静的な50単元データをFirestoreと同じ形式で返す（オフライン/空コレクション用フォールバック）
- */
-export function getStaticMasterUnits() {
-  return MASTER_UNITS_DATA.map(u => ({
+export function getStaticMasterUnits(subject = null) {
+  const mapped = MASTER_UNITS_DATA.map(u => ({
     id: u.id,
     name: u.name,
-    subject: u.subject || '算数',
+    subject: u.subject,
     category: u.category,
     difficultyLevel: u.difficulty_level || null,
     description: u.description || '',
     orderIndex: u.order_index || 0,
     isActive: true,
   }))
+  return subject ? mapped.filter(u => u.subject === subject) : mapped
+}
+
+/**
+ * Firestoreに単元マスタをインポート（管理者用・初回 or 更新時に実行）
+ * @param {Function} onProgress - 進捗コールバック (current, total, message)
+ * @returns {Promise<{success: number, failed: number, errors: Array}>}
+ */
+export async function importMasterUnitsToFirestore(onProgress = null) {
+  const results = { success: 0, failed: 0, errors: [] }
+  const total = MASTER_UNITS_DATA.length
+
+  for (let i = 0; i < MASTER_UNITS_DATA.length; i++) {
+    const unit = MASTER_UNITS_DATA[i]
+    try {
+      if (onProgress) onProgress(i + 1, total, `インポート中: ${unit.subject} / ${unit.name}`)
+      await setDoc(doc(db, 'masterUnits', unit.id), {
+        id: unit.id,
+        name: unit.name,
+        subject: unit.subject,
+        category: unit.category,
+        difficultyLevel: unit.difficulty_level || null,
+        description: unit.description || '',
+        orderIndex: unit.order_index || 0,
+        isActive: true,
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+      })
+      results.success++
+    } catch (error) {
+      console.error(`エラー: ${unit.id}`, error)
+      results.failed++
+      results.errors.push({ id: unit.id, name: unit.name, error: error.message })
+    }
+  }
+  return results
 }
 
 /**
  * masterUnitsコレクションが空の場合に自動シードする
- * @returns {Promise<boolean>} - シードした場合はtrue
+ * @returns {Promise<boolean>} シードした場合は true
  */
 export async function ensureMasterUnitsSeeded() {
   try {
     const snapshot = await getDocs(collection(db, 'masterUnits'))
-    if (!snapshot.empty) return false // 既にデータあり
+    if (!snapshot.empty) return false
     await importMasterUnitsToFirestore()
     return true
   } catch (err) {
@@ -169,31 +103,21 @@ export async function ensureMasterUnitsSeeded() {
 }
 
 /**
- * 統計情報を取得
+ * 教科・カテゴリ別の統計情報を返す
  * @returns {Object}
  */
 export function getMasterUnitsStats() {
-  const categoryMap = {}
-
-  MASTER_UNITS_DATA.forEach(unit => {
-    if (!categoryMap[unit.category]) {
-      categoryMap[unit.category] = {
-        count: 0,
-        totalDifficulty: 0
-      }
+  const bySubject = {}
+  MASTER_UNITS_DATA.forEach(u => {
+    if (!bySubject[u.subject]) bySubject[u.subject] = { count: 0, categories: {} }
+    bySubject[u.subject].count++
+    if (!bySubject[u.subject].categories[u.category]) {
+      bySubject[u.subject].categories[u.category] = 0
     }
-    categoryMap[unit.category].count++
-    categoryMap[unit.category].totalDifficulty += unit.difficulty_level || 0
+    bySubject[u.subject].categories[u.category]++
   })
-
-  const categoryStats = Object.entries(categoryMap).map(([category, data]) => ({
-    category,
-    count: data.count,
-    avgDifficulty: (data.totalDifficulty / data.count).toFixed(1)
-  }))
-
   return {
     totalUnits: MASTER_UNITS_DATA.length,
-    categories: categoryStats.sort((a, b) => a.category.localeCompare(b.category))
+    bySubject,
   }
 }

--- a/child-learning-app/src/utils/masterUnits/kokugo.js
+++ b/child-learning-app/src/utils/masterUnits/kokugo.js
@@ -1,0 +1,69 @@
+/**
+ * 国語 マスター単元データ（50単元）
+ * ID命名規則: KOK_カテゴリ略語_単元略語
+ * difficulty_level: 1=基礎〜5=最難問
+ * order_index: 1001〜1500（算数と重複しないよう1000番台）
+ */
+export const KOKUGO_UNITS = [
+  // 読解技術：論理・構造 (14)
+  { id: 'KOK_LOG_DEMONST',    name: '指示語',             category: '読解技術：論理・構造', difficulty_level: 2, order_index: 1010 },
+  { id: 'KOK_LOG_CONJ',       name: '接続詞',             category: '読解技術：論理・構造', difficulty_level: 2, order_index: 1020 },
+  { id: 'KOK_LOG_PARA',       name: '意味段落',           category: '読解技術：論理・構造', difficulty_level: 3, order_index: 1030 },
+  { id: 'KOK_LOG_SUMMARY',    name: '要点・要旨',         category: '読解技術：論理・構造', difficulty_level: 3, order_index: 1040 },
+  { id: 'KOK_LOG_CONTRAST',   name: '対比',               category: '読解技術：論理・構造', difficulty_level: 3, order_index: 1050 },
+  { id: 'KOK_LOG_ABSTRACT',   name: '抽象・具体',         category: '読解技術：論理・構造', difficulty_level: 3, order_index: 1060 },
+  { id: 'KOK_LOG_REASON',     name: '理由説明',           category: '読解技術：論理・構造', difficulty_level: 3, order_index: 1070 },
+  { id: 'KOK_LOG_SCENE',      name: '場面・情景',         category: '読解技術：論理・構造', difficulty_level: 3, order_index: 1080 },
+  { id: 'KOK_LOG_CHAR_REL',   name: '人物相関',           category: '読解技術：論理・構造', difficulty_level: 3, order_index: 1090 },
+  { id: 'KOK_LOG_EMOTION',    name: '心情',               category: '読解技術：論理・構造', difficulty_level: 4, order_index: 1100 },
+  { id: 'KOK_LOG_PERSON',     name: '性格・人柄',         category: '読解技術：論理・構造', difficulty_level: 3, order_index: 1110 },
+  { id: 'KOK_LOG_DESC',       name: '情景描写',           category: '読解技術：論理・構造', difficulty_level: 3, order_index: 1120 },
+  { id: 'KOK_LOG_THEME',      name: '主題',               category: '読解技術：論理・構造', difficulty_level: 4, order_index: 1130 },
+  { id: 'KOK_LOG_FORESHADOW', name: '伏線',               category: '読解技術：論理・構造', difficulty_level: 4, order_index: 1140 },
+
+  // 読解ジャンル (6)
+  { id: 'KOK_GEN_STORY',   name: '物語文',               category: '読解ジャンル', difficulty_level: 3, order_index: 1150 },
+  { id: 'KOK_GEN_EXPLAIN', name: '説明文',               category: '読解ジャンル', difficulty_level: 3, order_index: 1160 },
+  { id: 'KOK_GEN_ESSAY',   name: '随筆文',               category: '読解ジャンル', difficulty_level: 3, order_index: 1170 },
+  { id: 'KOK_GEN_POEM',    name: '詩',                   category: '読解ジャンル', difficulty_level: 3, order_index: 1180 },
+  { id: 'KOK_GEN_HAIKU',   name: '短歌・俳句',           category: '読解ジャンル', difficulty_level: 3, order_index: 1190 },
+  { id: 'KOK_GEN_THESIS',  name: '論説文',               category: '読解ジャンル', difficulty_level: 4, order_index: 1200 },
+
+  // 解答技術・記述 (6)
+  { id: 'KOK_SKL_ELIM',    name: '消去法（選択肢）',     category: '解答技術・記述', difficulty_level: 2, order_index: 1210 },
+  { id: 'KOK_SKL_EXTRACT', name: '抜き出し',             category: '解答技術・記述', difficulty_level: 2, order_index: 1220 },
+  { id: 'KOK_SKL_SHORT',   name: '短文記述',             category: '解答技術・記述', difficulty_level: 3, order_index: 1230 },
+  { id: 'KOK_SKL_LONG',    name: '中長文記述',           category: '解答技術・記述', difficulty_level: 4, order_index: 1240 },
+  { id: 'KOK_SKL_SPEC',    name: '指定語句記述',         category: '解答技術・記述', difficulty_level: 4, order_index: 1250 },
+  { id: 'KOK_SKL_SUMMARY', name: '要約・作文',           category: '解答技術・記述', difficulty_level: 5, order_index: 1260 },
+
+  // 知識：漢字・語彙 (14)
+  { id: 'KOK_KNJ_WRITE',    name: '漢字書き',            category: '知識：漢字・語彙', difficulty_level: 1, order_index: 1270 },
+  { id: 'KOK_KNJ_READ',     name: '漢字読み',            category: '知識：漢字・語彙', difficulty_level: 1, order_index: 1280 },
+  { id: 'KOK_KNJ_HOMO',     name: '同音異義・同訓異字',  category: '知識：漢字・語彙', difficulty_level: 2, order_index: 1290 },
+  { id: 'KOK_KNJ_RADICAL',  name: '部首・画数',          category: '知識：漢字・語彙', difficulty_level: 2, order_index: 1300 },
+  { id: 'KOK_KNJ_COMPOUND', name: '三字・四字熟語',      category: '知識：漢字・語彙', difficulty_level: 3, order_index: 1310 },
+  { id: 'KOK_KNJ_SYNONYM',  name: '類義語・対義語',      category: '知識：漢字・語彙', difficulty_level: 2, order_index: 1320 },
+  { id: 'KOK_KNJ_PROVERB',  name: 'ことわざ・故事成語',  category: '知識：漢字・語彙', difficulty_level: 3, order_index: 1330 },
+  { id: 'KOK_KNJ_IDIOM',    name: '慣用句',              category: '知識：漢字・語彙', difficulty_level: 2, order_index: 1340 },
+  { id: 'KOK_KNJ_KEIGO',    name: '敬語（知識）',        category: '知識：漢字・語彙', difficulty_level: 3, order_index: 1350 },
+  { id: 'KOK_KNJ_KATA',     name: 'カタカナ語',          category: '知識：漢字・語彙', difficulty_level: 2, order_index: 1360 },
+  { id: 'KOK_KNJ_EMOTION',  name: '心情語',              category: '知識：漢字・語彙', difficulty_level: 3, order_index: 1370 },
+  { id: 'KOK_KNJ_ABSTRACT', name: '抽象語・論理語',      category: '知識：漢字・語彙', difficulty_level: 3, order_index: 1380 },
+  { id: 'KOK_KNJ_KIGO',     name: '季語',                category: '知識：漢字・語彙', difficulty_level: 2, order_index: 1390 },
+  { id: 'KOK_KNJ_DIFFICULT',name: '難読漢字',            category: '知識：漢字・語彙', difficulty_level: 4, order_index: 1400 },
+
+  // 知識：文法・きまり (6)
+  { id: 'KOK_GRAM_STRUCT',   name: '文の構造（主述・修飾）', category: '知識：文法・きまり', difficulty_level: 2, order_index: 1410 },
+  { id: 'KOK_GRAM_PARTS',    name: '品詞',                   category: '知識：文法・きまり', difficulty_level: 3, order_index: 1420 },
+  { id: 'KOK_GRAM_VERB',     name: '動詞の活用',             category: '知識：文法・きまり', difficulty_level: 3, order_index: 1430 },
+  { id: 'KOK_GRAM_PARTICLE', name: '助詞・助動詞',           category: '知識：文法・きまり', difficulty_level: 3, order_index: 1440 },
+  { id: 'KOK_GRAM_KEIGO',    name: '敬語（文法）',           category: '知識：文法・きまり', difficulty_level: 4, order_index: 1450 },
+  { id: 'KOK_GRAM_RHETORIC', name: '修辞技法（比喩等）',     category: '知識：文法・きまり', difficulty_level: 3, order_index: 1460 },
+
+  // その他・発展 (4)
+  { id: 'KOK_ADV_CLASSIC',    name: '古文・漢文（基礎）',   category: 'その他・発展', difficulty_level: 4, order_index: 1470 },
+  { id: 'KOK_ADV_LITHISTORY', name: '文学史',               category: 'その他・発展', difficulty_level: 3, order_index: 1480 },
+  { id: 'KOK_ADV_DATA',       name: '資料・図表読解',       category: 'その他・発展', difficulty_level: 3, order_index: 1490 },
+  { id: 'KOK_ADV_MULTI',      name: '複数テキスト比較',     category: 'その他・発展', difficulty_level: 5, order_index: 1500 },
+]

--- a/child-learning-app/src/utils/masterUnits/rika.js
+++ b/child-learning-app/src/utils/masterUnits/rika.js
@@ -1,0 +1,65 @@
+/**
+ * 理科 マスター単元データ（50単元）
+ * ID命名規則: RIK_分野略語_単元略語
+ * difficulty_level: 1=基礎〜5=最難問
+ * order_index: 2001〜2500（2000番台）
+ */
+export const RIKA_UNITS = [
+  // 生物分野 (14)
+  { id: 'RIK_BIO_INSECT',       name: '昆虫の育ちと体',         category: '生物分野', difficulty_level: 2, order_index: 2010 },
+  { id: 'RIK_BIO_INSECT_SEAS',  name: '昆虫の冬越し・季節',     category: '生物分野', difficulty_level: 2, order_index: 2020 },
+  { id: 'RIK_BIO_PLANT_GROW',   name: '植物の発芽と成長',       category: '生物分野', difficulty_level: 2, order_index: 2030 },
+  { id: 'RIK_BIO_FLOWER',       name: '花のつくりと受粉',       category: '生物分野', difficulty_level: 3, order_index: 2040 },
+  { id: 'RIK_BIO_PLANT_PART',   name: '根・茎・葉のつくり',     category: '生物分野', difficulty_level: 3, order_index: 2050 },
+  { id: 'RIK_BIO_PHOTO',        name: '植物の光合成・呼吸',     category: '生物分野', difficulty_level: 4, order_index: 2060 },
+  { id: 'RIK_BIO_PLANT_CLASS',  name: '植物の分類と季節',       category: '生物分野', difficulty_level: 2, order_index: 2070 },
+  { id: 'RIK_BIO_FISH',         name: 'メダカ・魚の育ち',       category: '生物分野', difficulty_level: 2, order_index: 2080 },
+  { id: 'RIK_BIO_BODY_BONE',    name: 'ヒトの体（骨・筋肉）',   category: '生物分野', difficulty_level: 2, order_index: 2090 },
+  { id: 'RIK_BIO_DIGEST',       name: 'ヒトの体（消化・吸収）', category: '生物分野', difficulty_level: 3, order_index: 2100 },
+  { id: 'RIK_BIO_BREATH',       name: 'ヒトの体（呼吸・循環）', category: '生物分野', difficulty_level: 3, order_index: 2110 },
+  { id: 'RIK_BIO_BIRTH',        name: 'ヒトの体（誕生・変化）', category: '生物分野', difficulty_level: 3, order_index: 2120 },
+  { id: 'RIK_BIO_ANIMAL',       name: '動物の分類と生活',       category: '生物分野', difficulty_level: 3, order_index: 2130 },
+  { id: 'RIK_BIO_ECOLOGY',      name: '生態系と環境',           category: '生物分野', difficulty_level: 4, order_index: 2140 },
+
+  // 地学分野 (12)
+  { id: 'RIK_GEO_SUN_DAY',  name: '太陽の動き（日周運動）', category: '地学分野', difficulty_level: 3, order_index: 2150 },
+  { id: 'RIK_GEO_SUN_YEAR', name: '太陽の動き（年周運動）', category: '地学分野', difficulty_level: 4, order_index: 2160 },
+  { id: 'RIK_GEO_MOON',     name: '月の満ち欠けと動き',     category: '地学分野', difficulty_level: 3, order_index: 2170 },
+  { id: 'RIK_GEO_STAR',     name: '星の動きと星座',         category: '地学分野', difficulty_level: 3, order_index: 2180 },
+  { id: 'RIK_GEO_PLANET',   name: '惑星と太陽系',           category: '地学分野', difficulty_level: 3, order_index: 2190 },
+  { id: 'RIK_GEO_RIVER',    name: '流れる水の働き',         category: '地学分野', difficulty_level: 3, order_index: 2200 },
+  { id: 'RIK_GEO_LAYER',    name: '地層の重なりと化石',     category: '地学分野', difficulty_level: 3, order_index: 2210 },
+  { id: 'RIK_GEO_VOLCANO',  name: '火山と岩石',             category: '地学分野', difficulty_level: 3, order_index: 2220 },
+  { id: 'RIK_GEO_QUAKE',    name: '地震の伝わり方',         category: '地学分野', difficulty_level: 3, order_index: 2230 },
+  { id: 'RIK_GEO_WEATHER',  name: '天気の変化・雲',         category: '地学分野', difficulty_level: 3, order_index: 2240 },
+  { id: 'RIK_GEO_CLIMATE',  name: '日本の気候と気象',       category: '地学分野', difficulty_level: 3, order_index: 2250 },
+  { id: 'RIK_GEO_ENV',      name: '環境問題（温暖化等）',   category: '地学分野', difficulty_level: 3, order_index: 2260 },
+
+  // 物理分野 (14)
+  { id: 'RIK_PHY_MIRROR',       name: '鏡と光の進み方',           category: '物理分野', difficulty_level: 2, order_index: 2270 },
+  { id: 'RIK_PHY_LENS',         name: '凸レンズと光',             category: '物理分野', difficulty_level: 3, order_index: 2280 },
+  { id: 'RIK_PHY_SOUND',        name: '音の性質と伝わり方',       category: '物理分野', difficulty_level: 2, order_index: 2290 },
+  { id: 'RIK_PHY_HEAT',         name: '熱の伝わり方',             category: '物理分野', difficulty_level: 2, order_index: 2300 },
+  { id: 'RIK_PHY_EXPAND',       name: '物質の膨張と温度',         category: '物理分野', difficulty_level: 3, order_index: 2310 },
+  { id: 'RIK_PHY_CIRCUIT_BASIC',name: '豆電球と乾電池',           category: '物理分野', difficulty_level: 2, order_index: 2320 },
+  { id: 'RIK_PHY_MAGNET',       name: '電流と磁石（電磁石）',     category: '物理分野', difficulty_level: 3, order_index: 2330 },
+  { id: 'RIK_PHY_CIRCUIT',      name: '回路と抵抗',               category: '物理分野', difficulty_level: 4, order_index: 2340 },
+  { id: 'RIK_PHY_SCALE',        name: '上皿天秤・バネばかり',     category: '物理分野', difficulty_level: 2, order_index: 2350 },
+  { id: 'RIK_PHY_LEVER',        name: 'てこの原理',               category: '物理分野', difficulty_level: 4, order_index: 2360 },
+  { id: 'RIK_PHY_PULLEY',       name: 'かっ車・輪軸',             category: '物理分野', difficulty_level: 4, order_index: 2370 },
+  { id: 'RIK_PHY_SLOPE',        name: '斜面・ねじ・仕事',         category: '物理分野', difficulty_level: 4, order_index: 2380 },
+  { id: 'RIK_PHY_PENDULUM',     name: '振り子の運動',             category: '物理分野', difficulty_level: 3, order_index: 2390 },
+  { id: 'RIK_PHY_MOTION',       name: '物体の運動（衝突等）',     category: '物理分野', difficulty_level: 4, order_index: 2400 },
+
+  // 化学分野 (10)
+  { id: 'RIK_CHE_DISSOLVE',  name: '物の溶け方（溶解度）',           category: '化学分野', difficulty_level: 3, order_index: 2410 },
+  { id: 'RIK_CHE_ACID',      name: '水溶液の性質（酸・アルカリ）',   category: '化学分野', difficulty_level: 4, order_index: 2420 },
+  { id: 'RIK_CHE_NEUTRAL',   name: '水溶液の中和反応',               category: '化学分野', difficulty_level: 5, order_index: 2430 },
+  { id: 'RIK_CHE_METAL',     name: '金属と水溶液の反応',             category: '化学分野', difficulty_level: 4, order_index: 2440 },
+  { id: 'RIK_CHE_GAS_BASIC', name: '気体の発生（酸素・二酸化炭素）', category: '化学分野', difficulty_level: 3, order_index: 2450 },
+  { id: 'RIK_CHE_GAS_TYPE',  name: '気体の性質（水素・アンモニア等）',category: '化学分野', difficulty_level: 3, order_index: 2460 },
+  { id: 'RIK_CHE_BURN',      name: '燃焼の仕組み',                   category: '化学分野', difficulty_level: 4, order_index: 2470 },
+  { id: 'RIK_CHE_STATE',     name: '状態変化（氷・水・水蒸気）',     category: '化学分野', difficulty_level: 2, order_index: 2480 },
+  { id: 'RIK_CHE_SEPARATE',  name: '分離の工夫（ろ過・蒸留）',       category: '化学分野', difficulty_level: 3, order_index: 2490 },
+  { id: 'RIK_CHE_TOOLS',     name: '化学器具の使い方',               category: '化学分野', difficulty_level: 2, order_index: 2500 },
+]

--- a/child-learning-app/src/utils/masterUnits/sansu.js
+++ b/child-learning-app/src/utils/masterUnits/sansu.js
@@ -1,0 +1,79 @@
+/**
+ * 算数 マスター単元データ（50単元）
+ * ID命名規則: カテゴリ略語_単元略語
+ * difficulty_level: 1=基礎〜5=最難問
+ * order_index: 10単位で採番（後から挿入しやすくするため）
+ */
+export const SANSU_UNITS = [
+  // 計算 (4)
+  { id: 'CALC_BASIC',    name: '四則計算の基礎',    category: '計算',       difficulty_level: 1, order_index: 10 },
+  { id: 'CALC_TRICK',   name: '計算のくふう',       category: '計算',       difficulty_level: 2, order_index: 20 },
+  { id: 'CALC_UNIT',    name: '単位換算',            category: '計算',       difficulty_level: 2, order_index: 30 },
+  { id: 'CALC_BOX',     name: '□を求める計算',      category: '計算',       difficulty_level: 2, order_index: 40 },
+
+  // 数の性質 (1)
+  { id: 'NUM_DIVISOR',  name: '約数・倍数',          category: '数の性質',   difficulty_level: 3, order_index: 50 },
+
+  // 規則性 (4)
+  { id: 'PATTERN_SEQ',      name: '規則性(数列)',    category: '規則性',     difficulty_level: 3, order_index: 60 },
+  { id: 'PATTERN_TABLE',    name: '数表',            category: '規則性',     difficulty_level: 3, order_index: 70 },
+  { id: 'PATTERN_CALENDAR', name: '日暦算',          category: '規則性',     difficulty_level: 2, order_index: 80 },
+  { id: 'PATTERN_CYCLE',    name: '周期算',          category: '規則性',     difficulty_level: 3, order_index: 90 },
+
+  // 特殊算 (15)
+  { id: 'SPEC_WACHA',   name: '和差算',              category: '特殊算',     difficulty_level: 2, order_index: 100 },
+  { id: 'SPEC_AGE',     name: '年齢算',              category: '特殊算',     difficulty_level: 2, order_index: 110 },
+  { id: 'SPEC_TSURU',   name: 'つるかめ算',          category: '特殊算',     difficulty_level: 3, order_index: 120 },
+  { id: 'SPEC_DIFF',    name: '差集め算',            category: '特殊算',     difficulty_level: 3, order_index: 130 },
+  { id: 'SPEC_EXCESS',  name: '過不足算',            category: '特殊算',     difficulty_level: 3, order_index: 140 },
+  { id: 'SPEC_TREE',    name: '植木算',              category: '特殊算',     difficulty_level: 2, order_index: 150 },
+  { id: 'SPEC_SQUARE',  name: '方陣算',              category: '特殊算',     difficulty_level: 3, order_index: 160 },
+  { id: 'SPEC_DISTRIB', name: '分配算',              category: '特殊算',     difficulty_level: 3, order_index: 170 },
+  { id: 'SPEC_EQUIV',   name: '相当算',              category: '特殊算',     difficulty_level: 3, order_index: 180 },
+  { id: 'SPEC_RESTORE', name: '還元算',              category: '特殊算',     difficulty_level: 3, order_index: 190 },
+  { id: 'SPEC_MULTIPLE',name: '倍数算',              category: '特殊算',     difficulty_level: 3, order_index: 200 },
+  { id: 'SPEC_ELIM',    name: '消去算',              category: '特殊算',     difficulty_level: 4, order_index: 210 },
+  { id: 'SPEC_AVG',     name: '平均算',              category: '特殊算',     difficulty_level: 2, order_index: 220 },
+  { id: 'SPEC_WORK',    name: '仕事算',              category: '特殊算',     difficulty_level: 4, order_index: 230 },
+  { id: 'SPEC_NEWTON',  name: 'ニュートン算',        category: '特殊算',     difficulty_level: 5, order_index: 240 },
+
+  // 速さ (5)
+  { id: 'SPEED_BASIC',  name: '速さの基本',          category: '速さ',       difficulty_level: 2, order_index: 250 },
+  { id: 'SPEED_TRAVEL', name: '旅人算',              category: '速さ',       difficulty_level: 3, order_index: 260 },
+  { id: 'SPEED_PASS',   name: '通過算',              category: '速さ',       difficulty_level: 3, order_index: 270 },
+  { id: 'SPEED_RIVER',  name: '流水算',              category: '速さ',       difficulty_level: 3, order_index: 280 },
+  { id: 'SPEED_CLOCK',  name: '時計算',              category: '速さ',       difficulty_level: 4, order_index: 290 },
+
+  // 割合 (3)
+  { id: 'RATIO_BASIC',  name: '割合の基本',          category: '割合',       difficulty_level: 2, order_index: 300 },
+  { id: 'RATIO_PROFIT', name: '売買損益',            category: '割合',       difficulty_level: 3, order_index: 310 },
+  { id: 'RATIO_CONC',   name: '食塩水',              category: '割合',       difficulty_level: 4, order_index: 320 },
+
+  // 比 (3)
+  { id: 'PROP_BASIC',   name: '比の基本',            category: '比',         difficulty_level: 3, order_index: 330 },
+  { id: 'PROP_RATIO',   name: '比例・反比例',        category: '比',         difficulty_level: 3, order_index: 340 },
+  { id: 'PROP_SPEED',   name: '速さと比',            category: '比',         difficulty_level: 4, order_index: 350 },
+
+  // 平面図形 (7)
+  { id: 'PLANE_ANGLE',   name: '角度',               category: '平面図形',   difficulty_level: 2, order_index: 360 },
+  { id: 'PLANE_AREA',    name: '面積',               category: '平面図形',   difficulty_level: 2, order_index: 370 },
+  { id: 'PLANE_CIRCLE',  name: '円・おうぎ形',       category: '平面図形',   difficulty_level: 3, order_index: 380 },
+  { id: 'PLANE_EQUIV',   name: '等積変形',           category: '平面図形',   difficulty_level: 4, order_index: 390 },
+  { id: 'PLANE_MOVE',    name: '図形の移動',         category: '平面図形',   difficulty_level: 3, order_index: 400 },
+  { id: 'PLANE_SIMILAR', name: '相似',               category: '平面図形',   difficulty_level: 4, order_index: 410 },
+  { id: 'PLANE_RATIO',   name: '面積比・線分比',     category: '平面図形',   difficulty_level: 5, order_index: 420 },
+
+  // 立体図形 (5)
+  { id: 'SOLID_BASIC',   name: '立体の名前・展開図', category: '立体図形',   difficulty_level: 2, order_index: 430 },
+  { id: 'SOLID_VOLUME',  name: '体積・表面積',       category: '立体図形',   difficulty_level: 3, order_index: 440 },
+  { id: 'SOLID_CUT',     name: '立体の切断',         category: '立体図形',   difficulty_level: 5, order_index: 450 },
+  { id: 'SOLID_ROTATE',  name: '回転体',             category: '立体図形',   difficulty_level: 4, order_index: 460 },
+  { id: 'SOLID_WATER',   name: '水位の変化',         category: '立体図形',   difficulty_level: 4, order_index: 470 },
+
+  // 場合の数 (1)
+  { id: 'COMB_COUNT',    name: '場合の数',           category: '場合の数',   difficulty_level: 4, order_index: 480 },
+
+  // グラフ・論理 (2)
+  { id: 'LOGIC_GRAPH',   name: 'グラフ',             category: 'グラフ・論理', difficulty_level: 3, order_index: 490 },
+  { id: 'LOGIC_COND',    name: '条件整理・論理',     category: 'グラフ・論理', difficulty_level: 4, order_index: 500 },
+]

--- a/child-learning-app/src/utils/masterUnits/shakai.js
+++ b/child-learning-app/src/utils/masterUnits/shakai.js
@@ -1,0 +1,67 @@
+/**
+ * 社会 マスター単元データ（50単元）
+ * ID命名規則: SHA_分野略語_単元略語
+ * difficulty_level: 1=基礎〜5=最難問
+ * order_index: 3001〜3500（3000番台）
+ */
+export const SHAKAI_UNITS = [
+  // 地理分野：地域・産業 (19)
+  { id: 'SHA_GEO_MAP',       name: '地図の見方・記号',                   category: '地理分野：地域・産業', difficulty_level: 1, order_index: 3010 },
+  { id: 'SHA_GEO_LAND',      name: '日本の国土と地形（山地・平野・川）', category: '地理分野：地域・産業', difficulty_level: 2, order_index: 3020 },
+  { id: 'SHA_GEO_CLIMATE',   name: '日本の気候と自然災害',               category: '地理分野：地域・産業', difficulty_level: 2, order_index: 3030 },
+  { id: 'SHA_GEO_CROP',      name: '農作物の栽培と地域',                 category: '地理分野：地域・産業', difficulty_level: 2, order_index: 3040 },
+  { id: 'SHA_GEO_LIVESTOCK', name: '畜産業と酪農',                       category: '地理分野：地域・産業', difficulty_level: 2, order_index: 3050 },
+  { id: 'SHA_GEO_FISHERY',   name: '水産業（漁法・漁港）',               category: '地理分野：地域・産業', difficulty_level: 3, order_index: 3060 },
+  { id: 'SHA_GEO_RESOURCE',  name: '資源とエネルギー',                   category: '地理分野：地域・産業', difficulty_level: 3, order_index: 3070 },
+  { id: 'SHA_GEO_INDUSTRY',  name: '工業地帯・地域の特色',               category: '地理分野：地域・産業', difficulty_level: 3, order_index: 3080 },
+  { id: 'SHA_GEO_CRAFT',     name: '伝統的工芸品',                       category: '地理分野：地域・産業', difficulty_level: 2, order_index: 3090 },
+  { id: 'SHA_GEO_TRADE',     name: '貿易と運輸（港・空港）',             category: '地理分野：地域・産業', difficulty_level: 3, order_index: 3100 },
+  { id: 'SHA_GEO_INFO',      name: '情報化社会と通信',                   category: '地理分野：地域・産業', difficulty_level: 2, order_index: 3110 },
+  { id: 'SHA_GEO_HOKKAIDO',  name: '北海道地方',                         category: '地理分野：地域・産業', difficulty_level: 2, order_index: 3120 },
+  { id: 'SHA_GEO_TOHOKU',    name: '東北地方',                           category: '地理分野：地域・産業', difficulty_level: 2, order_index: 3130 },
+  { id: 'SHA_GEO_KANTO',     name: '関東地方',                           category: '地理分野：地域・産業', difficulty_level: 3, order_index: 3140 },
+  { id: 'SHA_GEO_CHUBU',     name: '中部地方',                           category: '地理分野：地域・産業', difficulty_level: 3, order_index: 3150 },
+  { id: 'SHA_GEO_KINKI',     name: '近畿地方',                           category: '地理分野：地域・産業', difficulty_level: 3, order_index: 3160 },
+  { id: 'SHA_GEO_CHUGOKU',   name: '中国・四国地方',                     category: '地理分野：地域・産業', difficulty_level: 2, order_index: 3170 },
+  { id: 'SHA_GEO_KYUSHU',    name: '九州・沖縄地方',                     category: '地理分野：地域・産業', difficulty_level: 2, order_index: 3180 },
+  { id: 'SHA_GEO_PREF',      name: '都道府県と県庁所在地',               category: '地理分野：地域・産業', difficulty_level: 1, order_index: 3190 },
+
+  // 歴史分野：古代〜近世 (10)
+  { id: 'SHA_HIST_ANCIENT',   name: '旧石器・縄文・弥生時代',             category: '歴史分野：古代〜近世', difficulty_level: 2, order_index: 3200 },
+  { id: 'SHA_HIST_ASUKA',     name: '古墳・飛鳥時代（聖徳太子）',         category: '歴史分野：古代〜近世', difficulty_level: 2, order_index: 3210 },
+  { id: 'SHA_HIST_NARA',      name: '奈良時代（平城京）',                 category: '歴史分野：古代〜近世', difficulty_level: 2, order_index: 3220 },
+  { id: 'SHA_HIST_HEIAN',     name: '平安時代（摂関政治・国風文化）',     category: '歴史分野：古代〜近世', difficulty_level: 3, order_index: 3230 },
+  { id: 'SHA_HIST_KAMAKURA',  name: '鎌倉時代（幕府の成立・蒙古襲来）',  category: '歴史分野：古代〜近世', difficulty_level: 3, order_index: 3240 },
+  { id: 'SHA_HIST_MUROMACHI', name: '室町時代（文化・戦国大名）',         category: '歴史分野：古代〜近世', difficulty_level: 3, order_index: 3250 },
+  { id: 'SHA_HIST_AZUCHI',    name: '安土桃山時代（織豊政権）',           category: '歴史分野：古代〜近世', difficulty_level: 3, order_index: 3260 },
+  { id: 'SHA_HIST_EDO1',      name: '江戸時代（幕藩体制・鎖国）',         category: '歴史分野：古代〜近世', difficulty_level: 3, order_index: 3270 },
+  { id: 'SHA_HIST_EDO2',      name: '江戸時代（産業・改革・学問）',       category: '歴史分野：古代〜近世', difficulty_level: 3, order_index: 3280 },
+  { id: 'SHA_HIST_BAKUMATSU', name: '幕末と開国',                         category: '歴史分野：古代〜近世', difficulty_level: 3, order_index: 3290 },
+
+  // 歴史分野：近代〜現代 (8)
+  { id: 'SHA_MOD_MEIJI',   name: '明治維新と富国強兵',             category: '歴史分野：近代〜現代', difficulty_level: 3, order_index: 3300 },
+  { id: 'SHA_MOD_WAR',     name: '条約改正と日清・日露戦争',       category: '歴史分野：近代〜現代', difficulty_level: 3, order_index: 3310 },
+  { id: 'SHA_MOD_TAISHO',  name: '大正デモクラシーと政党政治',     category: '歴史分野：近代〜現代', difficulty_level: 3, order_index: 3320 },
+  { id: 'SHA_MOD_SHOWA',   name: '昭和（戦前・戦中）',             category: '歴史分野：近代〜現代', difficulty_level: 4, order_index: 3330 },
+  { id: 'SHA_MOD_POSTWAR', name: '占領下の日本と戦後改革',         category: '歴史分野：近代〜現代', difficulty_level: 3, order_index: 3340 },
+  { id: 'SHA_MOD_GROWTH',  name: '高度経済成長と現代の日本',       category: '歴史分野：近代〜現代', difficulty_level: 3, order_index: 3350 },
+  { id: 'SHA_MOD_CULTURE', name: '日本の文化史（全時代）',         category: '歴史分野：近代〜現代', difficulty_level: 4, order_index: 3360 },
+  { id: 'SHA_MOD_FOREIGN', name: '外交史（大陸との交流）',         category: '歴史分野：近代〜現代', difficulty_level: 4, order_index: 3370 },
+
+  // 公民分野：憲法・政治 (9)
+  { id: 'SHA_CIVIC_CONST',    name: '日本国憲法（三原則）',             category: '公民分野：憲法・政治', difficulty_level: 3, order_index: 3380 },
+  { id: 'SHA_CIVIC_EMPEROR',  name: '天皇と平和主義',                   category: '公民分野：憲法・政治', difficulty_level: 3, order_index: 3390 },
+  { id: 'SHA_CIVIC_RIGHTS',   name: '基本的人権の尊重',                 category: '公民分野：憲法・政治', difficulty_level: 3, order_index: 3400 },
+  { id: 'SHA_CIVIC_DIET',     name: '国会（立法）',                     category: '公民分野：憲法・政治', difficulty_level: 3, order_index: 3410 },
+  { id: 'SHA_CIVIC_CABINET',  name: '内閣（行政）',                     category: '公民分野：憲法・政治', difficulty_level: 3, order_index: 3420 },
+  { id: 'SHA_CIVIC_COURT',    name: '裁判所（司法・三権分立）',         category: '公民分野：憲法・政治', difficulty_level: 3, order_index: 3430 },
+  { id: 'SHA_CIVIC_LOCAL',    name: '地方自治',                         category: '公民分野：憲法・政治', difficulty_level: 2, order_index: 3440 },
+  { id: 'SHA_CIVIC_ELECTION', name: '選挙と政党',                       category: '公民分野：憲法・政治', difficulty_level: 3, order_index: 3450 },
+  { id: 'SHA_CIVIC_ECON',     name: '経済の仕組み・税金・社会保障',     category: '公民分野：憲法・政治', difficulty_level: 4, order_index: 3460 },
+
+  // 時事・国際・環境 (4)
+  { id: 'SHA_NEWS_UN',      name: '国際連合（UN）の働き',       category: '時事・国際・環境', difficulty_level: 3, order_index: 3470 },
+  { id: 'SHA_NEWS_WORLD',   name: '世界の国々と日本',           category: '時事・国際・環境', difficulty_level: 2, order_index: 3480 },
+  { id: 'SHA_NEWS_ENV',     name: '環境問題・SDGs',             category: '時事・国際・環境', difficulty_level: 3, order_index: 3490 },
+  { id: 'SHA_NEWS_CURRENT', name: '時事問題（最新のニュース）', category: '時事・国際・環境', difficulty_level: 3, order_index: 3500 },
+]


### PR DESCRIPTION
- masterUnits/ フォルダに教科別データファイルを分離
  - sansu.js:  算数 50単元（既存データを移行）
  - kokugo.js: 国語 50単元（新規）
  - rika.js:   理科 50単元（新規）
  - shakai.js: 社会 50単元（新規）
- importMasterUnits.js を全教科対応に刷新
  - SUBJECTS 定数（教科名・カラー）を export
  - getStaticMasterUnits(subject?) に教科フィルター引数を追加
  - getMasterUnitsStats() を教科別集計に変更
- 単元追加・変更は各教科ファイルを編集するだけでOK

https://claude.ai/code/session_01TdzUBCnxia3ienbEbhZLfs