### PR TITLE
タブ名称を変更し、単元バッジをID→名称表示に修正

### DIFF
--- a/child-learning-app/src/App.jsx
+++ b/child-learning-app/src/App.jsx
@@ -295,13 +295,13 @@ function App() {
             className={view === 'schedule' ? 'active' : ''}
             onClick={() => setView('schedule')}
           >
-            📅 スケジュール
+            📅 今週のミッション
           </button>
           <button
             className={view === 'sapixtext' ? 'active' : ''}
             onClick={() => setView('sapixtext')}
           >
-            📘 サピックス課題
+            📘 授業・教材
           </button>
           <button
             className={view === 'pastpaper' ? 'active' : ''}
@@ -325,7 +325,7 @@ function App() {
             className={view === 'dashboard' ? 'active' : ''}
             onClick={() => setView('dashboard')}
           >
-            🏠 ダッシュボード
+            🗺️ 弱点マップ
           </button>
         </div>
 

--- a/child-learning-app/src/components/SapixTextView.jsx
+++ b/child-learning-app/src/components/SapixTextView.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import './SapixTextView.css'
 import { subjects, grades } from '../utils/unitsDatabase'
 import { subjectColors, subjectEmojis } from '../utils/constants'
@@ -9,10 +9,18 @@ import { toast } from '../utils/toast'
 import DriveFilePicker from './DriveFilePicker'
 import UnitTagPicker from './UnitTagPicker'
 import { addLessonLogWithStats, EVALUATION_SCORES, EVALUATION_LABELS } from '../utils/lessonLogs'
+import { getStaticMasterUnits } from '../utils/importMasterUnits'
 
 function SapixTextView({ user }) {
   const [texts, setTexts] = useState([])
   const [selectedSubject, setSelectedSubject] = useState('算数')
+
+  // 単元IDから単元名へのマップ
+  const unitNameMap = useMemo(() => {
+    const map = {}
+    getStaticMasterUnits().forEach(u => { map[u.id] = u.name })
+    return map
+  }, [])
   const [showAddForm, setShowAddForm] = useState(false)
   const [editingId, setEditingId] = useState(null)
   const [viewingPDF, setViewingPDF] = useState(null)
@@ -513,7 +521,7 @@ function SapixTextView({ user }) {
                       {(text.unitIds?.length > 0) && (
                         <div className="sapix-unit-tags">
                           {text.unitIds.map(uid => (
-                            <span key={uid} className="sapix-unit-badge">{uid}</span>
+                            <span key={uid} className="sapix-unit-badge">{unitNameMap[uid] || uid}</span>
                           ))}
                         </div>
                       )}


### PR DESCRIPTION
- スケジュール → 今週のミッション
- サピックス課題 → 授業・教材
- ダッシュボード → 弱点マップ（🗺️）
- SapixTextView: 単元タグのバッジ表示をIDから単元名に変更

https://claude.ai/code/session_01TdzUBCnxia3ienbEbhZLfs