### PR TITLE
算数IDにSAN_プレフィックスを追加、単元ピッカーを教科でフィルタリング

### DIFF
--- a/child-learning-app/src/components/SapixTextView.jsx
+++ b/child-learning-app/src/components/SapixTextView.jsx
@@ -263,6 +263,7 @@ function SapixTextView({ user }) {
         <div className="sapix-form-section">
           <label className="sapix-section-label">単元タグ（複数選択可）:</label>
           <UnitTagPicker
+            subject={form.subject}
             value={form.unitIds}
             onChange={(unitIds) => setForm(prev => ({ ...prev, unitIds }))}
           />
@@ -365,7 +366,7 @@ function SapixTextView({ user }) {
                   key={subject}
                   type="button"
                   className={`subject-btn ${addForm.subject === subject ? 'active' : ''}`}
-                  onClick={() => setAddForm(prev => ({ ...prev, subject, unitId: '' }))}
+                  onClick={() => setAddForm(prev => ({ ...prev, subject, unitIds: [] }))}
                   style={{
                     borderColor: addForm.subject === subject ? subjectColors[subject] : '#e2e8f0',
                     background: addForm.subject === subject ? `${subjectColors[subject]}15` : 'white',
@@ -461,7 +462,7 @@ function SapixTextView({ user }) {
                           key={subject}
                           type="button"
                           className={`subject-btn ${editForm.subject === subject ? 'active' : ''}`}
-                          onClick={() => setEditForm(prev => ({ ...prev, subject, unitId: '' }))}
+                          onClick={() => setEditForm(prev => ({ ...prev, subject, unitIds: [] }))}
                           style={{
                             borderColor: editForm.subject === subject ? subjectColors[subject] : '#e2e8f0',
                             background: editForm.subject === subject ? `${subjectColors[subject]}15` : 'white',

--- a/child-learning-app/src/components/UnitTagPicker.jsx
+++ b/child-learning-app/src/components/UnitTagPicker.jsx
@@ -7,23 +7,29 @@ import './UnitTagPicker.css'
  *
  * @param {string[]} value - 選択済みの unitId 配列
  * @param {Function} onChange - (unitIds: string[]) => void
+ * @param {string} [subject] - 絞り込む教科名。指定時はその教科の単元のみドロップダウンに表示
  * @param {string} [placeholder] - 検索ボックスのプレースホルダー
  */
-function UnitTagPicker({ value = [], onChange, placeholder = '単元を検索...' }) {
-  const allUnits = getStaticMasterUnits()
+function UnitTagPicker({ value = [], onChange, subject = null, placeholder = '単元を検索...' }) {
+  const allUnits = useMemo(() => getStaticMasterUnits(), [])
+  const subjectUnits = useMemo(
+    () => subject ? getStaticMasterUnits(subject) : allUnits,
+    [allUnits, subject]
+  )
   const [searchText, setSearchText] = useState('')
   const [isOpen, setIsOpen] = useState(false)
 
   const filteredUnits = useMemo(() => {
-    if (!searchText.trim()) return allUnits
+    if (!searchText.trim()) return subjectUnits
     const q = searchText.toLowerCase()
-    return allUnits.filter(u =>
+    return subjectUnits.filter(u =>
       u.name?.toLowerCase().includes(q) ||
       u.category?.toLowerCase().includes(q) ||
       u.id?.toLowerCase().includes(q)
     )
-  }, [allUnits, searchText])
+  }, [subjectUnits, searchText])
 
+  // チップ表示は全教科から検索（科目変更前に選んだ単元も表示できるように）
   const selectedUnits = useMemo(() =>
     allUnits.filter(u => value.includes(u.id)),
     [allUnits, value]

--- a/child-learning-app/src/utils/masterUnits/sansu.js
+++ b/child-learning-app/src/utils/masterUnits/sansu.js
@@ -1,79 +1,79 @@
 /**
  * 算数 マスター単元データ（50単元）
- * ID命名規則: カテゴリ略語_単元略語
+ * ID命名規則: SAN_カテゴリ略語_単元略語
  * difficulty_level: 1=基礎〜5=最難問
  * order_index: 10単位で採番（後から挿入しやすくするため）
  */
 export const SANSU_UNITS = [
   // 計算 (4)
-  { id: 'CALC_BASIC',    name: '四則計算の基礎',    category: '計算',       difficulty_level: 1, order_index: 10 },
-  { id: 'CALC_TRICK',   name: '計算のくふう',       category: '計算',       difficulty_level: 2, order_index: 20 },
-  { id: 'CALC_UNIT',    name: '単位換算',            category: '計算',       difficulty_level: 2, order_index: 30 },
-  { id: 'CALC_BOX',     name: '□を求める計算',      category: '計算',       difficulty_level: 2, order_index: 40 },
+  { id: 'SAN_CALC_BASIC',    name: '四則計算の基礎',    category: '計算',       difficulty_level: 1, order_index: 10 },
+  { id: 'SAN_CALC_TRICK',   name: '計算のくふう',       category: '計算',       difficulty_level: 2, order_index: 20 },
+  { id: 'SAN_CALC_UNIT',    name: '単位換算',            category: '計算',       difficulty_level: 2, order_index: 30 },
+  { id: 'SAN_CALC_BOX',     name: '□を求める計算',      category: '計算',       difficulty_level: 2, order_index: 40 },
 
   // 数の性質 (1)
-  { id: 'NUM_DIVISOR',  name: '約数・倍数',          category: '数の性質',   difficulty_level: 3, order_index: 50 },
+  { id: 'SAN_NUM_DIVISOR',  name: '約数・倍数',          category: '数の性質',   difficulty_level: 3, order_index: 50 },
 
   // 規則性 (4)
-  { id: 'PATTERN_SEQ',      name: '規則性(数列)',    category: '規則性',     difficulty_level: 3, order_index: 60 },
-  { id: 'PATTERN_TABLE',    name: '数表',            category: '規則性',     difficulty_level: 3, order_index: 70 },
-  { id: 'PATTERN_CALENDAR', name: '日暦算',          category: '規則性',     difficulty_level: 2, order_index: 80 },
-  { id: 'PATTERN_CYCLE',    name: '周期算',          category: '規則性',     difficulty_level: 3, order_index: 90 },
+  { id: 'SAN_PATTERN_SEQ',      name: '規則性(数列)',    category: '規則性',     difficulty_level: 3, order_index: 60 },
+  { id: 'SAN_PATTERN_TABLE',    name: '数表',            category: '規則性',     difficulty_level: 3, order_index: 70 },
+  { id: 'SAN_PATTERN_CALENDAR', name: '日暦算',          category: '規則性',     difficulty_level: 2, order_index: 80 },
+  { id: 'SAN_PATTERN_CYCLE',    name: '周期算',          category: '規則性',     difficulty_level: 3, order_index: 90 },
 
   // 特殊算 (15)
-  { id: 'SPEC_WACHA',   name: '和差算',              category: '特殊算',     difficulty_level: 2, order_index: 100 },
-  { id: 'SPEC_AGE',     name: '年齢算',              category: '特殊算',     difficulty_level: 2, order_index: 110 },
-  { id: 'SPEC_TSURU',   name: 'つるかめ算',          category: '特殊算',     difficulty_level: 3, order_index: 120 },
-  { id: 'SPEC_DIFF',    name: '差集め算',            category: '特殊算',     difficulty_level: 3, order_index: 130 },
-  { id: 'SPEC_EXCESS',  name: '過不足算',            category: '特殊算',     difficulty_level: 3, order_index: 140 },
-  { id: 'SPEC_TREE',    name: '植木算',              category: '特殊算',     difficulty_level: 2, order_index: 150 },
-  { id: 'SPEC_SQUARE',  name: '方陣算',              category: '特殊算',     difficulty_level: 3, order_index: 160 },
-  { id: 'SPEC_DISTRIB', name: '分配算',              category: '特殊算',     difficulty_level: 3, order_index: 170 },
-  { id: 'SPEC_EQUIV',   name: '相当算',              category: '特殊算',     difficulty_level: 3, order_index: 180 },
-  { id: 'SPEC_RESTORE', name: '還元算',              category: '特殊算',     difficulty_level: 3, order_index: 190 },
-  { id: 'SPEC_MULTIPLE',name: '倍数算',              category: '特殊算',     difficulty_level: 3, order_index: 200 },
-  { id: 'SPEC_ELIM',    name: '消去算',              category: '特殊算',     difficulty_level: 4, order_index: 210 },
-  { id: 'SPEC_AVG',     name: '平均算',              category: '特殊算',     difficulty_level: 2, order_index: 220 },
-  { id: 'SPEC_WORK',    name: '仕事算',              category: '特殊算',     difficulty_level: 4, order_index: 230 },
-  { id: 'SPEC_NEWTON',  name: 'ニュートン算',        category: '特殊算',     difficulty_level: 5, order_index: 240 },
+  { id: 'SAN_SPEC_WACHA',   name: '和差算',              category: '特殊算',     difficulty_level: 2, order_index: 100 },
+  { id: 'SAN_SPEC_AGE',     name: '年齢算',              category: '特殊算',     difficulty_level: 2, order_index: 110 },
+  { id: 'SAN_SPEC_TSURU',   name: 'つるかめ算',          category: '特殊算',     difficulty_level: 3, order_index: 120 },
+  { id: 'SAN_SPEC_DIFF',    name: '差集め算',            category: '特殊算',     difficulty_level: 3, order_index: 130 },
+  { id: 'SAN_SPEC_EXCESS',  name: '過不足算',            category: '特殊算',     difficulty_level: 3, order_index: 140 },
+  { id: 'SAN_SPEC_TREE',    name: '植木算',              category: '特殊算',     difficulty_level: 2, order_index: 150 },
+  { id: 'SAN_SPEC_SQUARE',  name: '方陣算',              category: '特殊算',     difficulty_level: 3, order_index: 160 },
+  { id: 'SAN_SPEC_DISTRIB', name: '分配算',              category: '特殊算',     difficulty_level: 3, order_index: 170 },
+  { id: 'SAN_SPEC_EQUIV',   name: '相当算',              category: '特殊算',     difficulty_level: 3, order_index: 180 },
+  { id: 'SAN_SPEC_RESTORE', name: '還元算',              category: '特殊算',     difficulty_level: 3, order_index: 190 },
+  { id: 'SAN_SPEC_MULTIPLE',name: '倍数算',              category: '特殊算',     difficulty_level: 3, order_index: 200 },
+  { id: 'SAN_SPEC_ELIM',    name: '消去算',              category: '特殊算',     difficulty_level: 4, order_index: 210 },
+  { id: 'SAN_SPEC_AVG',     name: '平均算',              category: '特殊算',     difficulty_level: 2, order_index: 220 },
+  { id: 'SAN_SPEC_WORK',    name: '仕事算',              category: '特殊算',     difficulty_level: 4, order_index: 230 },
+  { id: 'SAN_SPEC_NEWTON',  name: 'ニュートン算',        category: '特殊算',     difficulty_level: 5, order_index: 240 },
 
   // 速さ (5)
-  { id: 'SPEED_BASIC',  name: '速さの基本',          category: '速さ',       difficulty_level: 2, order_index: 250 },
-  { id: 'SPEED_TRAVEL', name: '旅人算',              category: '速さ',       difficulty_level: 3, order_index: 260 },
-  { id: 'SPEED_PASS',   name: '通過算',              category: '速さ',       difficulty_level: 3, order_index: 270 },
-  { id: 'SPEED_RIVER',  name: '流水算',              category: '速さ',       difficulty_level: 3, order_index: 280 },
-  { id: 'SPEED_CLOCK',  name: '時計算',              category: '速さ',       difficulty_level: 4, order_index: 290 },
+  { id: 'SAN_SPEED_BASIC',  name: '速さの基本',          category: '速さ',       difficulty_level: 2, order_index: 250 },
+  { id: 'SAN_SPEED_TRAVEL', name: '旅人算',              category: '速さ',       difficulty_level: 3, order_index: 260 },
+  { id: 'SAN_SPEED_PASS',   name: '通過算',              category: '速さ',       difficulty_level: 3, order_index: 270 },
+  { id: 'SAN_SPEED_RIVER',  name: '流水算',              category: '速さ',       difficulty_level: 3, order_index: 280 },
+  { id: 'SAN_SPEED_CLOCK',  name: '時計算',              category: '速さ',       difficulty_level: 4, order_index: 290 },
 
   // 割合 (3)
-  { id: 'RATIO_BASIC',  name: '割合の基本',          category: '割合',       difficulty_level: 2, order_index: 300 },
-  { id: 'RATIO_PROFIT', name: '売買損益',            category: '割合',       difficulty_level: 3, order_index: 310 },
-  { id: 'RATIO_CONC',   name: '食塩水',              category: '割合',       difficulty_level: 4, order_index: 320 },
+  { id: 'SAN_RATIO_BASIC',  name: '割合の基本',          category: '割合',       difficulty_level: 2, order_index: 300 },
+  { id: 'SAN_RATIO_PROFIT', name: '売買損益',            category: '割合',       difficulty_level: 3, order_index: 310 },
+  { id: 'SAN_RATIO_CONC',   name: '食塩水',              category: '割合',       difficulty_level: 4, order_index: 320 },
 
   // 比 (3)
-  { id: 'PROP_BASIC',   name: '比の基本',            category: '比',         difficulty_level: 3, order_index: 330 },
-  { id: 'PROP_RATIO',   name: '比例・反比例',        category: '比',         difficulty_level: 3, order_index: 340 },
-  { id: 'PROP_SPEED',   name: '速さと比',            category: '比',         difficulty_level: 4, order_index: 350 },
+  { id: 'SAN_PROP_BASIC',   name: '比の基本',            category: '比',         difficulty_level: 3, order_index: 330 },
+  { id: 'SAN_PROP_RATIO',   name: '比例・反比例',        category: '比',         difficulty_level: 3, order_index: 340 },
+  { id: 'SAN_PROP_SPEED',   name: '速さと比',            category: '比',         difficulty_level: 4, order_index: 350 },
 
   // 平面図形 (7)
-  { id: 'PLANE_ANGLE',   name: '角度',               category: '平面図形',   difficulty_level: 2, order_index: 360 },
-  { id: 'PLANE_AREA',    name: '面積',               category: '平面図形',   difficulty_level: 2, order_index: 370 },
-  { id: 'PLANE_CIRCLE',  name: '円・おうぎ形',       category: '平面図形',   difficulty_level: 3, order_index: 380 },
-  { id: 'PLANE_EQUIV',   name: '等積変形',           category: '平面図形',   difficulty_level: 4, order_index: 390 },
-  { id: 'PLANE_MOVE',    name: '図形の移動',         category: '平面図形',   difficulty_level: 3, order_index: 400 },
-  { id: 'PLANE_SIMILAR', name: '相似',               category: '平面図形',   difficulty_level: 4, order_index: 410 },
-  { id: 'PLANE_RATIO',   name: '面積比・線分比',     category: '平面図形',   difficulty_level: 5, order_index: 420 },
+  { id: 'SAN_PLANE_ANGLE',   name: '角度',               category: '平面図形',   difficulty_level: 2, order_index: 360 },
+  { id: 'SAN_PLANE_AREA',    name: '面積',               category: '平面図形',   difficulty_level: 2, order_index: 370 },
+  { id: 'SAN_PLANE_CIRCLE',  name: '円・おうぎ形',       category: '平面図形',   difficulty_level: 3, order_index: 380 },
+  { id: 'SAN_PLANE_EQUIV',   name: '等積変形',           category: '平面図形',   difficulty_level: 4, order_index: 390 },
+  { id: 'SAN_PLANE_MOVE',    name: '図形の移動',         category: '平面図形',   difficulty_level: 3, order_index: 400 },
+  { id: 'SAN_PLANE_SIMILAR', name: '相似',               category: '平面図形',   difficulty_level: 4, order_index: 410 },
+  { id: 'SAN_PLANE_RATIO',   name: '面積比・線分比',     category: '平面図形',   difficulty_level: 5, order_index: 420 },
 
   // 立体図形 (5)
-  { id: 'SOLID_BASIC',   name: '立体の名前・展開図', category: '立体図形',   difficulty_level: 2, order_index: 430 },
-  { id: 'SOLID_VOLUME',  name: '体積・表面積',       category: '立体図形',   difficulty_level: 3, order_index: 440 },
-  { id: 'SOLID_CUT',     name: '立体の切断',         category: '立体図形',   difficulty_level: 5, order_index: 450 },
-  { id: 'SOLID_ROTATE',  name: '回転体',             category: '立体図形',   difficulty_level: 4, order_index: 460 },
-  { id: 'SOLID_WATER',   name: '水位の変化',         category: '立体図形',   difficulty_level: 4, order_index: 470 },
+  { id: 'SAN_SOLID_BASIC',   name: '立体の名前・展開図', category: '立体図形',   difficulty_level: 2, order_index: 430 },
+  { id: 'SAN_SOLID_VOLUME',  name: '体積・表面積',       category: '立体図形',   difficulty_level: 3, order_index: 440 },
+  { id: 'SAN_SOLID_CUT',     name: '立体の切断',         category: '立体図形',   difficulty_level: 5, order_index: 450 },
+  { id: 'SAN_SOLID_ROTATE',  name: '回転体',             category: '立体図形',   difficulty_level: 4, order_index: 460 },
+  { id: 'SAN_SOLID_WATER',   name: '水位の変化',         category: '立体図形',   difficulty_level: 4, order_index: 470 },
 
   // 場合の数 (1)
-  { id: 'COMB_COUNT',    name: '場合の数',           category: '場合の数',   difficulty_level: 4, order_index: 480 },
+  { id: 'SAN_COMB_COUNT',    name: '場合の数',           category: '場合の数',   difficulty_level: 4, order_index: 480 },
 
   // グラフ・論理 (2)
-  { id: 'LOGIC_GRAPH',   name: 'グラフ',             category: 'グラフ・論理', difficulty_level: 3, order_index: 490 },
-  { id: 'LOGIC_COND',    name: '条件整理・論理',     category: 'グラフ・論理', difficulty_level: 4, order_index: 500 },
+  { id: 'SAN_LOGIC_GRAPH',   name: 'グラフ',             category: 'グラフ・論理', difficulty_level: 3, order_index: 490 },
+  { id: 'SAN_LOGIC_COND',    name: '条件整理・論理',     category: 'グラフ・論理', difficulty_level: 4, order_index: 500 },
 ]


### PR DESCRIPTION
- sansu.js: 全50単元のIDをSAN_プレフィックス形式に統一 (CALC_* → SAN_CALC_*, SPEC_* → SAN_SPEC_* など) KOK_/RIK_/SHA_と同じ命名規則に揃える
- UnitTagPicker: subject propを追加 指定教科の単元のみドロップダウンに表示 選択済みチップは全教科から表示（科目変更前の選択も見える）
- SapixTextView: UnitTagPickerにsubjectを渡すよう修正 科目ボタン切り替え時にunitIdsをリセット

https://claude.ai/code/session_01TdzUBCnxia3ienbEbhZLfs