### PR TITLE
単元タグ選択順序を保持・メイン単元バッジ追加・過去問UIの一貫性修正

### DIFF
--- a/child-learning-app/src/components/PastPaperView.css
+++ b/child-learning-app/src/components/PastPaperView.css
@@ -63,7 +63,8 @@
   border: 2px solid #e0e7ff;
   max-width: 100%;
   min-width: 0;
-  overflow: hidden;
+  /* overflow: visible にしてUnitTagPickerのドロップダウンがクリップされないようにする */
+  overflow: visible;
 }
 
 .add-pastpaper-form h3 {
@@ -550,6 +551,11 @@
   max-width: 100%;
   min-width: 0;
   overflow: hidden;
+}
+
+/* 編集中はdropdownが見えるようにoverflowを解除 */
+.pastpaper-card.editing {
+  overflow: visible;
 }
 
 .pastpaper-card:hover {

--- a/child-learning-app/src/components/PastPaperView.jsx
+++ b/child-learning-app/src/components/PastPaperView.jsx
@@ -499,14 +499,14 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
           </div>
 
           {/* 問題ファイル */}
-          <div className="sapix-form-section">
-            <label className="sapix-section-label">問題PDF（任意）:</label>
+          <div className="add-form-section">
+            <label className="section-label">問題PDF（任意）:</label>
             {renderFileArea(addForm, setAddForm, 'add')}
           </div>
 
           {/* 単元タグ */}
-          <div className="sapix-form-section">
-            <label className="sapix-section-label">単元タグ（任意）:</label>
+          <div className="add-form-section">
+            <label className="section-label">単元タグ（任意）:</label>
             <UnitTagPicker
               subject={addForm.subject}
               value={addForm.unitIds}
@@ -554,7 +554,7 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
                   const taskUnitIds = getTaskUnitIds(task)
 
                   return (
-                    <div key={task.id} className="pastpaper-card">
+                    <div key={task.id} className={`pastpaper-card${editingTaskId === task.id ? ' editing' : ''}`}>
                       {editingTaskId === task.id ? (
                         // 編集モード
                         <div className="edit-form-container">
@@ -608,14 +608,14 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
                           </div>
 
                           {/* 問題ファイル */}
-                          <div className="sapix-form-section">
-                            <label className="sapix-section-label">問題PDF（任意）:</label>
+                          <div className="edit-form-section">
+                            <label className="section-label">問題PDF（任意）:</label>
                             {renderFileArea(editForm, setEditForm, task.id)}
                           </div>
 
                           {/* 単元タグ */}
-                          <div className="sapix-form-section">
-                            <label className="sapix-section-label">単元タグ（任意）:</label>
+                          <div className="edit-form-section">
+                            <label className="section-label">単元タグ（任意）:</label>
                             <UnitTagPicker
                               subject={editForm.subject}
                               value={editForm.unitIds}

--- a/child-learning-app/src/components/UnitTagPicker.css
+++ b/child-learning-app/src/components/UnitTagPicker.css
@@ -41,12 +41,29 @@
   display: inline-flex;
   align-items: center;
   gap: 3px;
-  padding: 2px 8px 2px 8px;
+  padding: 2px 8px;
   background: #dbeafe;
   color: #1d4ed8;
   border-radius: 12px;
   font-size: 12px;
   font-weight: 500;
+}
+
+/* メイン単元（最初に選択したタグ）は色を強調 */
+.utp-chip-main {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.utp-main-badge {
+  background: #f59e0b;
+  color: white;
+  font-size: 9px;
+  font-weight: 700;
+  padding: 1px 4px;
+  border-radius: 3px;
+  letter-spacing: 0.03em;
+  flex-shrink: 0;
 }
 
 .utp-chip-remove {

--- a/child-learning-app/src/components/UnitTagPicker.jsx
+++ b/child-learning-app/src/components/UnitTagPicker.jsx
@@ -29,9 +29,9 @@ function UnitTagPicker({ value = [], onChange, subject = null, placeholder = '�
     )
   }, [subjectUnits, searchText])
 
-  // チップ表示は全教科から検索（科目変更前に選んだ単元も表示できるように）
+  // チップ表示は value 配列の順序を維持（最初が「メイン単元」）
   const selectedUnits = useMemo(() =>
-    allUnits.filter(u => value.includes(u.id)),
+    value.map(id => allUnits.find(u => u.id === id)).filter(Boolean),
     [allUnits, value]
   )
 
@@ -70,8 +70,9 @@ function UnitTagPicker({ value = [], onChange, subject = null, placeholder = '�
           <span className="utp-placeholder">単元タグを選択（複数可）</span>
         ) : (
           <div className="utp-chips">
-            {selectedUnits.map(unit => (
-              <span key={unit.id} className="utp-chip">
+            {selectedUnits.map((unit, index) => (
+              <span key={unit.id} className={`utp-chip${index === 0 ? ' utp-chip-main' : ''}`}>
+                {index === 0 && <span className="utp-main-badge">メイン</span>}
                 {unit.name}
                 <button
                   className="utp-chip-remove"


### PR DESCRIPTION
[UnitTagPicker]
- 選択済みチップの表示順を選択した順番に変更（value配列の順序を維持）
  - 変更前: allUnits(order_index順)でfilterしていたため選択順が失われていた
  - 変更後: value.map(id => allUnits.find(...))で選択順を保持
- 一番最初に選択したタグを「メイン単元」と定義
  - メインチップにはオレンジ背景(#fef3c7)と「メイン」バッジを表示

[PastPaperView]
- CSS クラス修正: sapix-form-section/sapix-section-label（SapixTextView.cssにしか定義なし） → add-form-section/section-label（過去問固有の正しいクラス）に統一
- 編集フォームも同様にedit-form-section/section-labelに修正
- .add-pastpaper-form: overflow:hidden → overflow:visible （UnitTagPickerドロップダウンがクリップされないように）
- .pastpaper-card.editing: overflow:visible を追加 （カード内の編集フォームでドロップダウンが見えるように）

https://claude.ai/code/session_01TdzUBCnxia3ienbEbhZLfs