### PR TITLE
弱点マップv2: メイン単元/サブ単元設計・ミス種類分類を実装

### DIFF
--- a/child-learning-app/src/components/MasterUnitDashboard.css
+++ b/child-learning-app/src/components/MasterUnitDashboard.css
@@ -560,3 +560,70 @@
   color: #9ca3af;
   flex-shrink: 0;
 }
+
+/* 直接・間接カウント表示 */
+.mud-unit-counts {
+  display: flex;
+  gap: 3px;
+  justify-content: center;
+  margin-top: 1px;
+}
+
+.mud-direct-count {
+  font-size: 9px;
+  background: #dbeafe;
+  color: #1d4ed8;
+  padding: 1px 4px;
+  border-radius: 4px;
+  font-weight: 700;
+}
+
+.mud-indirect-count {
+  font-size: 9px;
+  background: #f3f4f6;
+  color: #6b7280;
+  padding: 1px 4px;
+  border-radius: 4px;
+  font-weight: 600;
+}
+
+/* 共起サブ単元 */
+.mud-cooccurring {
+  margin: 10px 0;
+  padding: 10px 12px;
+  background: #f8fafc;
+  border-radius: 8px;
+  border: 1px solid #e2e8f0;
+}
+
+.mud-cooccurring-label {
+  font-size: 11px;
+  color: #6b7280;
+  font-weight: 600;
+  display: block;
+  margin-bottom: 6px;
+}
+
+.mud-cooccurring-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.mud-cooccurring-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 3px 8px;
+  background: #e0f2fe;
+  color: #0369a1;
+  border-radius: 10px;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.mud-cooccurring-count {
+  font-size: 10px;
+  color: #0284c7;
+  font-weight: 700;
+}

--- a/child-learning-app/src/components/TestScoreView.css
+++ b/child-learning-app/src/components/TestScoreView.css
@@ -1360,3 +1360,100 @@
     flex-wrap: wrap;
   }
 }
+
+/* ミスの種類選択 */
+.miss-type-btns {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.miss-type-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 8px 14px;
+  border: 2px solid #e5e7eb;
+  border-radius: 10px;
+  background: white;
+  cursor: pointer;
+  transition: all 0.15s;
+  min-width: 90px;
+}
+
+.miss-type-btn:hover {
+  border-color: #9ca3af;
+  background: #f9fafb;
+}
+
+.miss-type-btn.selected.miss-understanding {
+  border-color: #dc2626;
+  background: #fee2e2;
+}
+
+.miss-type-btn.selected.miss-careless {
+  border-color: #ca8a04;
+  background: #fef9c3;
+}
+
+.miss-type-btn.selected.miss-not-studied {
+  border-color: #6b7280;
+  background: #f3f4f6;
+}
+
+.miss-type-btn.selected {
+  border-color: #3b82f6;
+  background: #eff6ff;
+}
+
+.miss-type-icon {
+  font-size: 18px;
+}
+
+.miss-type-label {
+  font-size: 12px;
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.miss-type-desc {
+  font-size: 10px;
+  color: #6b7280;
+}
+
+/* 不正解セル */
+.wrong-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+}
+
+.miss-badge {
+  font-size: 10px;
+  font-weight: 700;
+  padding: 1px 5px;
+  border-radius: 4px;
+  white-space: nowrap;
+}
+
+.miss-understanding {
+  background: #fee2e2;
+  color: #dc2626;
+}
+
+.miss-careless {
+  background: #fef9c3;
+  color: #a16207;
+}
+
+.miss-not-studied {
+  background: #f3f4f6;
+  color: #4b5563;
+}
+
+.miss-high-accuracy {
+  font-size: 13px;
+  cursor: default;
+}


### PR DESCRIPTION
- lessonLogs: mainUnitIdを追加、computeAllProficienciesでメイン単元のみ習熟度計算 サブ単元はindirectCountとして追跡
- MasterUnitDashboard: 直接/間接評価回数バッジ表示、ドリルダウンで共起単元を表示
- TestScoreView: 不正解時にミスの種類選択UI（理解不足/ケアレスミス/未習）を追加 理解不足のみ弱点マップに反映、高正答率ミスに⚠️マーカー表示

https://claude.ai/code/session_01TdzUBCnxia3ienbEbhZLfs