### PR TITLE
PDFから問題切り出し機能を追加

### DIFF
--- a/child-learning-app/package-lock.json
+++ b/child-learning-app/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "firebase": "^12.6.0",
+        "pdfjs-dist": "^5.4.624",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
@@ -1645,6 +1646,256 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.93",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.93.tgz",
+      "integrity": "sha512-unVFo8CUlUeJCCxt50+j4yy91NF4x6n9zdGcvEsOFAWzowtZm3mgx8X2D7xjwV0cFSfxmpGPoe+JS77uzeFsxg==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.93",
+        "@napi-rs/canvas-darwin-arm64": "0.1.93",
+        "@napi-rs/canvas-darwin-x64": "0.1.93",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.93",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.93",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.93",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.93",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.93",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.93",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.93",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.93"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.93",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.93.tgz",
+      "integrity": "sha512-xRIoOPFvneR29Dtq5d9p2AJbijDCFeV4jQ+5Ms/xVAXJVb8R0Jlu+pPr/SkhrG+Mouaml4roPSXugTIeRl6CMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.93",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.93.tgz",
+      "integrity": "sha512-daNDi76HN5grC6GXDmpxdfP+N2mQPd3sCfg62VyHwUuvbZh32P7R/IUjkzAxtYMtTza+Zvx9hfLJ3J7ENL6WMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.93",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.93.tgz",
+      "integrity": "sha512-1YfuNPIQLawsg/gSNdJRk4kQWUy9M/Gy8FGsOI79nhQEJ2PZdqpSPl5UNzf4elfuNXuVbEbmmjP68EQdUunDuQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.93",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.93.tgz",
+      "integrity": "sha512-8kEkOQPZjuyHjupvXExuJZiuiVNecdABGq3DLI7aO1EvQFOOlWMm2d/8Q5qXdV73Tn+nu3m16+kPajsN1oJefQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.93",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.93.tgz",
+      "integrity": "sha512-qIKLKkBkYSyWSYAoDThoxf5y1gr4X0g7W8rDU7d2HDeAAcotdVHUwuKkMeNe6+5VNk7/95EIhbslQjSxiCu32g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.93",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.93.tgz",
+      "integrity": "sha512-mAwQBGM3qArS9XEO21AK4E1uGvCuUCXjhIZk0dlVvs49MQ6wAAuCkYKNFpSKeSicKrLWwBMfgWX4qZoPh+M00A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.93",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.93.tgz",
+      "integrity": "sha512-kaIH5MpPzOZfkM+QMsBxGdM9jlJT+N+fwz2IEaju/S+DL65E5TgPOx4QcD5dQ8vsMxlak6uDrudBc4ns5xzZCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.93",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.93.tgz",
+      "integrity": "sha512-KtMZJqYWvOSeW5w3VSV2f5iGnwNdKJm4gwgVid4xNy1NFi+NJSyuglA1lX1u4wIPxizyxh8OW5c5Usf6oSOMNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.93",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.93.tgz",
+      "integrity": "sha512-qRZhOvlDBooRLX6V3/t9X9B+plZK+OrPLgfFixu0A1RO/3VHbubOknfnMnocSDAqk/L6cRyKI83VP2ciR9UO7w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.93",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.93.tgz",
+      "integrity": "sha512-um5XE44vF8bjkQEsH2iRSUP9fDeQGYbn/qjM/v4whXG83qsqapAXlOPOQqSARZB1SiNvPUAuXoRsJLlKFmAEFw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.93",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.93.tgz",
+      "integrity": "sha512-maHlizZgmKsAPJwjwBZMnsWfq3Ca9QutoteQwKe7YqsmbECoylrLCCOGCDOredstW4BRWqRTfCl6NJaVVeAQvQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -3511,6 +3762,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-readable-to-web-readable-stream": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/node-readable-to-web-readable-stream/-/node-readable-to-web-readable-stream-0.4.2.tgz",
+      "integrity": "sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -3619,6 +3877,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "5.4.624",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.4.624.tgz",
+      "integrity": "sha512-sm6TxKTtWv1Oh6n3C6J6a8odejb5uO4A4zo/2dgkHuC0iu8ZMAXOezEODkVaoVp8nX1Xzr+0WxFJJmUr45hQzg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.16.0 || >=22.3.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.88",
+        "node-readable-to-web-readable-stream": "^0.4.2"
       }
     },
     "node_modules/picocolors": {

--- a/child-learning-app/package.json
+++ b/child-learning-app/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "firebase": "^12.6.0",
+    "pdfjs-dist": "^5.4.624",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },

--- a/child-learning-app/src/components/PdfCropper.css
+++ b/child-learning-app/src/components/PdfCropper.css
@@ -1,0 +1,323 @@
+/* PdfCropper オーバーレイ */
+.pdfcropper-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 2000;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 20px;
+  overflow-y: auto;
+}
+
+.pdfcropper-modal {
+  background: white;
+  border-radius: 16px;
+  width: 100%;
+  max-width: 860px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  overflow: hidden;
+}
+
+/* ヘッダー */
+.pdfcropper-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid #e5e7eb;
+  background: #f8fafc;
+}
+
+.pdfcropper-title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: #1f2937;
+  margin: 0;
+}
+
+.pdfcropper-close {
+  background: none;
+  border: none;
+  font-size: 18px;
+  color: #6b7280;
+  cursor: pointer;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+}
+.pdfcropper-close:hover {
+  background: #e5e7eb;
+  color: #1f2937;
+}
+
+/* URL入力 */
+.pdfcropper-url-row {
+  display: flex;
+  gap: 8px;
+  padding: 14px 20px;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.pdfcropper-url-input {
+  flex: 1;
+  padding: 8px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  font-size: 13px;
+  color: #1f2937;
+  outline: none;
+}
+.pdfcropper-url-input:focus {
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.15);
+}
+
+.pdfcropper-load-btn {
+  padding: 8px 18px;
+  background: #3b82f6;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.pdfcropper-load-btn:hover:not(:disabled) {
+  background: #2563eb;
+}
+.pdfcropper-load-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+/* エラー */
+.pdfcropper-error {
+  margin: 0 20px 0;
+  padding: 10px 14px;
+  background: #fee2e2;
+  color: #dc2626;
+  border-radius: 8px;
+  font-size: 13px;
+}
+
+/* コントロールバー */
+.pdfcropper-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 20px;
+  background: #f8fafc;
+  border-bottom: 1px solid #f0f0f0;
+  flex-wrap: wrap;
+}
+
+.pdfcropper-page-nav {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.pdfcropper-page-btn {
+  width: 30px;
+  height: 30px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background: white;
+  cursor: pointer;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.pdfcropper-page-btn:hover:not(:disabled) {
+  background: #eff6ff;
+  border-color: #3b82f6;
+}
+.pdfcropper-page-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.pdfcropper-page-info {
+  font-size: 13px;
+  font-weight: 600;
+  color: #374151;
+  min-width: 48px;
+  text-align: center;
+}
+
+.pdfcropper-zoom {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  overflow: hidden;
+}
+.pdfcropper-zoom button {
+  width: 28px;
+  height: 28px;
+  border: none;
+  background: white;
+  cursor: pointer;
+  font-size: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.pdfcropper-zoom button:hover {
+  background: #eff6ff;
+}
+.pdfcropper-zoom span {
+  font-size: 12px;
+  font-weight: 600;
+  color: #374151;
+  min-width: 38px;
+  text-align: center;
+}
+
+.pdfcropper-hint {
+  font-size: 12px;
+  color: #6b7280;
+  margin-left: auto;
+}
+
+/* Canvas エリア */
+.pdfcropper-canvas-wrapper {
+  position: relative;
+  overflow: auto;
+  max-height: 420px;
+  background: #e5e7eb;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 10px;
+}
+
+.pdfcropper-canvas {
+  display: block;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.pdfcropper-overlay-canvas {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  cursor: crosshair;
+}
+
+/* プレビュー */
+.pdfcropper-preview-area {
+  padding: 14px 20px;
+  border-top: 1px solid #f0f0f0;
+  background: #fafafa;
+}
+
+.pdfcropper-preview-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 8px;
+}
+
+.pdfcropper-preview-scroll {
+  overflow-x: auto;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background: white;
+  max-height: 180px;
+  overflow-y: auto;
+  margin-bottom: 12px;
+}
+
+.pdfcropper-preview-img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+.pdfcropper-preview-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.pdfcropper-reselect-btn {
+  padding: 8px 18px;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  background: white;
+  color: #374151;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.pdfcropper-reselect-btn:hover {
+  background: #f9fafb;
+}
+
+.pdfcropper-confirm-btn {
+  padding: 8px 22px;
+  background: #10b981;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+}
+.pdfcropper-confirm-btn:hover:not(:disabled) {
+  background: #059669;
+}
+.pdfcropper-confirm-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+/* 空/ローディング状態 */
+.pdfcropper-empty,
+.pdfcropper-loading {
+  padding: 48px 20px;
+  text-align: center;
+  color: #9ca3af;
+  font-size: 14px;
+}
+
+.pdfcropper-loading::before {
+  content: '';
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  border: 2px solid #d1d5db;
+  border-top-color: #3b82f6;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  margin-right: 8px;
+  vertical-align: middle;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* レスポンシブ */
+@media (max-width: 640px) {
+  .pdfcropper-overlay {
+    padding: 10px;
+  }
+  .pdfcropper-canvas-wrapper {
+    max-height: 320px;
+  }
+}

--- a/child-learning-app/src/components/PdfCropper.jsx
+++ b/child-learning-app/src/components/PdfCropper.jsx
@@ -1,0 +1,305 @@
+import { useState, useRef, useEffect, useCallback } from 'react'
+import * as pdfjsLib from 'pdfjs-dist'
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage'
+import { storage } from '../firebase'
+import { getGoogleAccessToken, refreshGoogleAccessToken } from './Auth'
+import './PdfCropper.css'
+
+// Use unpkg CDN for the worker to avoid bundler complexity
+pdfjsLib.GlobalWorkerOptions.workerSrc =
+  `https://unpkg.com/pdfjs-dist@${pdfjsLib.version}/build/pdf.worker.min.mjs`
+
+function extractDriveFileId(url) {
+  if (!url) return null
+  const match = url.match(/\/file\/d\/([^/?\s]+)/)
+  return match ? match[1] : null
+}
+
+export default function PdfCropper({ userId, onCropComplete, onClose }) {
+  const [urlInput, setUrlInput] = useState('')
+  const [pdfDoc, setPdfDoc] = useState(null)
+  const [currentPage, setCurrentPage] = useState(1)
+  const [totalPages, setTotalPages] = useState(0)
+  const [scale, setScale] = useState(1.5)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [selection, setSelection] = useState(null)
+  const [isDragging, setIsDragging] = useState(false)
+  const [dragStart, setDragStart] = useState(null)
+  const [croppedPreview, setCroppedPreview] = useState(null)
+  const [croppedBlob, setCroppedBlob] = useState(null)
+  const [isUploading, setIsUploading] = useState(false)
+
+  const canvasRef = useRef(null)
+  const overlayRef = useRef(null)
+  const renderTaskRef = useRef(null)
+
+  const clearOverlay = useCallback(() => {
+    const overlay = overlayRef.current
+    if (!overlay) return
+    overlay.getContext('2d').clearRect(0, 0, overlay.width, overlay.height)
+  }, [])
+
+  const renderPage = useCallback(async (doc, pageNum, sc) => {
+    if (!doc || !canvasRef.current) return
+    if (renderTaskRef.current) renderTaskRef.current.cancel()
+
+    const page = await doc.getPage(pageNum)
+    const viewport = page.getViewport({ scale: sc })
+
+    const canvas = canvasRef.current
+    canvas.width = viewport.width
+    canvas.height = viewport.height
+
+    const overlay = overlayRef.current
+    if (overlay) {
+      overlay.width = viewport.width
+      overlay.height = viewport.height
+    }
+
+    const task = page.render({ canvasContext: canvas.getContext('2d'), viewport })
+    renderTaskRef.current = task
+    try {
+      await task.promise
+    } catch (e) {
+      if (e.name !== 'RenderingCancelledException') console.error(e)
+    }
+
+    setSelection(null)
+    setCroppedPreview(null)
+    setCroppedBlob(null)
+    clearOverlay()
+  }, [clearOverlay])
+
+  useEffect(() => {
+    if (pdfDoc) renderPage(pdfDoc, currentPage, scale)
+  }, [pdfDoc, currentPage, scale, renderPage])
+
+  function drawSelectionRect(sel) {
+    const overlay = overlayRef.current
+    if (!overlay || !sel) return
+    const ctx = overlay.getContext('2d')
+    ctx.clearRect(0, 0, overlay.width, overlay.height)
+    // dim outside selection
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.3)'
+    ctx.fillRect(0, 0, overlay.width, overlay.height)
+    ctx.clearRect(sel.x, sel.y, sel.w, sel.h)
+    // border
+    ctx.strokeStyle = '#3b82f6'
+    ctx.lineWidth = 2
+    ctx.setLineDash([5, 3])
+    ctx.strokeRect(sel.x, sel.y, sel.w, sel.h)
+  }
+
+  function getCanvasPos(e) {
+    const overlay = overlayRef.current
+    const rect = overlay.getBoundingClientRect()
+    return {
+      x: (e.clientX - rect.left) * (overlay.width / rect.width),
+      y: (e.clientY - rect.top) * (overlay.height / rect.height),
+    }
+  }
+
+  const handleMouseDown = (e) => {
+    const pos = getCanvasPos(e)
+    setIsDragging(true)
+    setDragStart(pos)
+    setSelection(null)
+    setCroppedPreview(null)
+    setCroppedBlob(null)
+    clearOverlay()
+  }
+
+  const handleMouseMove = (e) => {
+    if (!isDragging || !dragStart) return
+    const pos = getCanvasPos(e)
+    const sel = normRect(dragStart, pos)
+    drawSelectionRect(sel)
+  }
+
+  const handleMouseUp = (e) => {
+    if (!isDragging) return
+    setIsDragging(false)
+    const pos = getCanvasPos(e)
+    const sel = normRect(dragStart, pos)
+    if (sel.w < 10 || sel.h < 10) { clearOverlay(); return }
+    setSelection(sel)
+    drawSelectionRect(sel)
+    cropToPreview(sel)
+  }
+
+  function normRect(a, b) {
+    return {
+      x: Math.min(a.x, b.x),
+      y: Math.min(a.y, b.y),
+      w: Math.abs(b.x - a.x),
+      h: Math.abs(b.y - a.y),
+    }
+  }
+
+  function cropToPreview(sel) {
+    const src = canvasRef.current
+    if (!src) return
+    const tmp = document.createElement('canvas')
+    tmp.width = sel.w
+    tmp.height = sel.h
+    tmp.getContext('2d').drawImage(src, sel.x, sel.y, sel.w, sel.h, 0, 0, sel.w, sel.h)
+    setCroppedPreview(tmp.toDataURL('image/png'))
+    tmp.toBlob(blob => setCroppedBlob(blob), 'image/png')
+  }
+
+  const handleLoadPdf = async () => {
+    const fileId = extractDriveFileId(urlInput)
+    if (!fileId) {
+      setError('Google DriveのURLを入力してください（例: https://drive.google.com/file/d/.../view）')
+      return
+    }
+    setIsLoading(true)
+    setError('')
+    setPdfDoc(null)
+
+    try {
+      let token = getGoogleAccessToken()
+      if (!token) token = await refreshGoogleAccessToken()
+      if (!token) throw new Error('Googleアカウントに再ログインしてください')
+
+      const response = await fetch(
+        `https://www.googleapis.com/drive/v3/files/${fileId}?alt=media`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      )
+      if (!response.ok) throw new Error(`PDFの読み込みに失敗しました (${response.status})`)
+
+      const arrayBuffer = await response.arrayBuffer()
+      const doc = await pdfjsLib.getDocument({ data: arrayBuffer }).promise
+      setPdfDoc(doc)
+      setTotalPages(doc.numPages)
+      setCurrentPage(1)
+    } catch (e) {
+      setError(e.message || 'PDFの読み込みに失敗しました')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleConfirmCrop = async () => {
+    if (!croppedBlob) return
+    setIsUploading(true)
+    try {
+      const storageRef = ref(storage, `problemImages/${userId}/${Date.now()}.png`)
+      await uploadBytes(storageRef, croppedBlob)
+      const url = await getDownloadURL(storageRef)
+      onCropComplete(url)
+    } catch (e) {
+      setError('画像の保存に失敗しました: ' + e.message)
+    } finally {
+      setIsUploading(false)
+    }
+  }
+
+  return (
+    <div className="pdfcropper-overlay" onClick={onClose}>
+      <div className="pdfcropper-modal" onClick={e => e.stopPropagation()}>
+
+        {/* ヘッダー */}
+        <div className="pdfcropper-header">
+          <h3 className="pdfcropper-title">PDFから問題を切り出す</h3>
+          <button className="pdfcropper-close" onClick={onClose}>✕</button>
+        </div>
+
+        {/* URL入力 */}
+        <div className="pdfcropper-url-row">
+          <input
+            className="pdfcropper-url-input"
+            type="text"
+            placeholder="Google Drive URL を貼り付け（例: https://drive.google.com/file/d/.../view）"
+            value={urlInput}
+            onChange={e => setUrlInput(e.target.value)}
+            onKeyDown={e => e.key === 'Enter' && handleLoadPdf()}
+          />
+          <button
+            className="pdfcropper-load-btn"
+            onClick={handleLoadPdf}
+            disabled={isLoading}
+          >
+            {isLoading ? '読込中...' : '読込'}
+          </button>
+        </div>
+
+        {error && <div className="pdfcropper-error">{error}</div>}
+
+        {/* PDFビュー */}
+        {pdfDoc && (
+          <>
+            <div className="pdfcropper-controls">
+              <div className="pdfcropper-page-nav">
+                <button
+                  className="pdfcropper-page-btn"
+                  onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
+                  disabled={currentPage <= 1}
+                >←</button>
+                <span className="pdfcropper-page-info">{currentPage} / {totalPages}</span>
+                <button
+                  className="pdfcropper-page-btn"
+                  onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))}
+                  disabled={currentPage >= totalPages}
+                >→</button>
+              </div>
+              <div className="pdfcropper-zoom">
+                <button onClick={() => setScale(s => Math.max(0.5, Math.round((s - 0.25) * 100) / 100))}>−</button>
+                <span>{Math.round(scale * 100)}%</span>
+                <button onClick={() => setScale(s => Math.min(3, Math.round((s + 0.25) * 100) / 100))}>＋</button>
+              </div>
+              <span className="pdfcropper-hint">ドラッグで問題範囲を選択</span>
+            </div>
+
+            <div className="pdfcropper-canvas-wrapper">
+              <canvas ref={canvasRef} className="pdfcropper-canvas" />
+              <canvas
+                ref={overlayRef}
+                className="pdfcropper-overlay-canvas"
+                onMouseDown={handleMouseDown}
+                onMouseMove={handleMouseMove}
+                onMouseUp={handleMouseUp}
+                onMouseLeave={handleMouseUp}
+              />
+            </div>
+
+            {croppedPreview && (
+              <div className="pdfcropper-preview-area">
+                <div className="pdfcropper-preview-label">選択範囲のプレビュー</div>
+                <div className="pdfcropper-preview-scroll">
+                  <img src={croppedPreview} alt="crop preview" className="pdfcropper-preview-img" />
+                </div>
+                <div className="pdfcropper-preview-actions">
+                  <button
+                    className="pdfcropper-reselect-btn"
+                    onClick={() => { setCroppedPreview(null); setCroppedBlob(null); clearOverlay(); setSelection(null) }}
+                  >
+                    選び直す
+                  </button>
+                  <button
+                    className="pdfcropper-confirm-btn"
+                    onClick={handleConfirmCrop}
+                    disabled={isUploading}
+                  >
+                    {isUploading ? '保存中...' : 'この範囲で確定'}
+                  </button>
+                </div>
+              </div>
+            )}
+          </>
+        )}
+
+        {!pdfDoc && !isLoading && (
+          <div className="pdfcropper-empty">
+            Google Drive の PDF URL を貼り付けて「読込」を押してください
+          </div>
+        )}
+
+        {isLoading && (
+          <div className="pdfcropper-loading">PDFを読み込んでいます...</div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/child-learning-app/src/components/TestScoreView.css
+++ b/child-learning-app/src/components/TestScoreView.css
@@ -1457,3 +1457,86 @@
   font-size: 13px;
   cursor: default;
 }
+
+/* PDFから取り込むボタン */
+.problem-add-btns {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.btn-pdf-crop {
+  padding: 6px 14px;
+  background: white;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #374151;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.btn-pdf-crop:hover {
+  background: #eff6ff;
+  border-color: #3b82f6;
+  color: #2563eb;
+}
+
+/* 問題番号セルの画像サムネイル */
+.cell-num {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+}
+
+.problem-img-thumb-link {
+  display: block;
+}
+
+.problem-img-thumb {
+  width: 40px;
+  height: 28px;
+  object-fit: cover;
+  border-radius: 3px;
+  border: 1px solid #e5e7eb;
+  cursor: zoom-in;
+}
+.problem-img-thumb:hover {
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
+}
+
+/* フォーム内画像プレビュー */
+.problem-form-image-preview {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px;
+  background: #f8fafc;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+}
+
+.problem-form-image-preview img {
+  max-width: 100%;
+  max-height: 160px;
+  border-radius: 6px;
+  object-fit: contain;
+  flex: 1;
+}
+
+.btn-remove-image {
+  padding: 4px 10px;
+  font-size: 11px;
+  font-weight: 600;
+  background: white;
+  border: 1px solid #fca5a5;
+  border-radius: 6px;
+  color: #dc2626;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.btn-remove-image:hover {
+  background: #fee2e2;
+}


### PR DESCRIPTION
- pdfjs-distをインストール（ブラウザ内PDFレンダリング）
- PdfCropper.jsx: Google Drive URLからPDFを読み込み、ドラッグで問題範囲を切り出す
  - 既存のGoogle OAuth(drive.readonly)トークンで認証・取得
  - ページナビゲーション・ズーム対応
  - 選択範囲をFirebase Storageに保存してURLを返す
- TestScoreView: 「PDFから取り込む」ボタン追加
  - 切り出し完了後、画像付きで問題追加フォームを開く
  - 問題テーブルにサムネイル表示（クリックで拡大）
  - problemLogsにimageUrlフィールドを追加

https://claude.ai/code/session_01TdzUBCnxia3ienbEbhZLfs