### PR TITLE
PDFと問題記録の連携構造をPhase 1で整備

### DIFF
--- a/child-learning-app/src/components/PDFProblemView.jsx
+++ b/child-learning-app/src/components/PDFProblemView.jsx
@@ -28,7 +28,8 @@ function PDFProblemView({ user }) {
     subject: '算数',
     schoolName: '',
     year: new Date().getFullYear(),
-    description: ''
+    description: '',
+    type: 'textbook'
   })
 
   const fileInputRef = useRef(null)
@@ -129,7 +130,8 @@ function PDFProblemView({ user }) {
           subject: '算数',
           schoolName: '',
           year: new Date().getFullYear(),
-          description: ''
+          description: '',
+          type: 'textbook'
         })
       } else {
         toast.error('アップロードに失敗しました: ' + result.error)
@@ -349,6 +351,20 @@ function PDFProblemView({ user }) {
         <div className="upload-form-overlay" onClick={() => !uploading && setShowUploadForm(false)}>
           <div className="upload-form-container" onClick={(e) => e.stopPropagation()}>
             <h3>PDFをアップロード（Google Drive）</h3>
+
+            <div className="form-field">
+              <label>種類 *</label>
+              <select
+                value={uploadMetadata.type}
+                onChange={(e) => setUploadMetadata({ ...uploadMetadata, type: e.target.value })}
+                disabled={uploading}
+              >
+                <option value="testPaper">テスト問題用紙</option>
+                <option value="textbook">教材テキスト（SAPIX等）</option>
+                <option value="pastPaper">過去問</option>
+                <option value="workbook">市販の問題集</option>
+              </select>
+            </div>
 
             <div className="form-field">
               <label>科目 *</label>

--- a/child-learning-app/src/components/PdfCropper.css
+++ b/child-learning-app/src/components/PdfCropper.css
@@ -312,6 +312,150 @@
   to { transform: rotate(360deg); }
 }
 
+/* タブ */
+.pdfcropper-tabs {
+  display: flex;
+  border-bottom: 1px solid #e5e7eb;
+  background: #f8fafc;
+}
+
+.pdfcropper-tab {
+  flex: 1;
+  padding: 10px 6px;
+  border: none;
+  background: none;
+  font-size: 12px;
+  font-weight: 600;
+  color: #6b7280;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition: color 0.15s, border-color 0.15s;
+}
+.pdfcropper-tab:hover { color: #374151; }
+.pdfcropper-tab.active {
+  color: #2563eb;
+  border-bottom-color: #2563eb;
+  background: white;
+}
+
+/* 紐付けPDF表示バー */
+.pdfcropper-attached-info {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 20px;
+  border-bottom: 1px solid #f0f0f0;
+  background: #f0f9ff;
+}
+.pdfcropper-attached-name {
+  flex: 1;
+  font-size: 13px;
+  font-weight: 500;
+  color: #0369a1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* 読み込み済みバー */
+.pdfcropper-loaded-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 16px;
+  background: #f0fdf4;
+  border-bottom: 1px solid #bbf7d0;
+  font-size: 12px;
+}
+.pdfcropper-loaded-name {
+  flex: 1;
+  color: #166534;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.pdfcropper-unload-btn {
+  background: none;
+  border: 1px solid #86efac;
+  border-radius: 6px;
+  color: #16a34a;
+  font-size: 11px;
+  padding: 3px 8px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.pdfcropper-unload-btn:hover { background: #dcfce7; }
+
+/* PDF登録済みリスト */
+.pdfcropper-list-area {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 340px;
+  overflow-y: auto;
+}
+
+.pdfcropper-list-search {
+  padding: 7px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  font-size: 13px;
+  outline: none;
+}
+.pdfcropper-list-search:focus { border-color: #3b82f6; }
+
+.pdfcropper-pdf-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.pdfcropper-pdf-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background: white;
+}
+
+.pdfcropper-pdf-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.pdfcropper-pdf-name {
+  display: block;
+  font-size: 13px;
+  font-weight: 500;
+  color: #1f2937;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pdfcropper-pdf-meta {
+  display: flex;
+  gap: 4px;
+  margin-top: 3px;
+  flex-wrap: wrap;
+}
+
+.pdfcropper-pdf-tag {
+  font-size: 10px;
+  padding: 1px 6px;
+  background: #f1f5f9;
+  border-radius: 4px;
+  color: #475569;
+  font-weight: 600;
+}
+
 /* レスポンシブ */
 @media (max-width: 640px) {
   .pdfcropper-overlay {

--- a/child-learning-app/src/components/TestScoreView.css
+++ b/child-learning-app/src/components/TestScoreView.css
@@ -1540,3 +1540,170 @@
 .btn-remove-image:hover {
   background: #fee2e2;
 }
+
+/* ─────────────────────────────────────────
+   PDF紐付けバー
+───────────────────────────────────────── */
+.pdf-attach-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  background: #f0f9ff;
+  border-bottom: 1px solid #bae6fd;
+  font-size: 13px;
+  flex-wrap: wrap;
+}
+
+.pdf-attach-label {
+  color: #0369a1;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.pdf-attach-name {
+  color: #1f2937;
+  font-weight: 500;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pdf-attach-add {
+  background: none;
+  border: 1px dashed #0ea5e9;
+  border-radius: 6px;
+  color: #0ea5e9;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 3px 12px;
+  cursor: pointer;
+}
+.pdf-attach-add:hover {
+  background: #e0f2fe;
+}
+
+.pdf-attach-change {
+  background: none;
+  border: 1px solid #93c5fd;
+  border-radius: 6px;
+  color: #2563eb;
+  font-size: 11px;
+  padding: 2px 8px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.pdf-attach-change:hover { background: #eff6ff; }
+
+.pdf-attach-remove {
+  background: none;
+  border: none;
+  color: #94a3b8;
+  font-size: 14px;
+  cursor: pointer;
+  padding: 2px 4px;
+  line-height: 1;
+}
+.pdf-attach-remove:hover { color: #dc2626; }
+
+/* PDFピッカーモーダル */
+.pdf-picker-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.5);
+  z-index: 1500;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.pdf-picker-modal {
+  background: white;
+  border-radius: 12px;
+  width: 100%;
+  max-width: 520px;
+  max-height: 70vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 10px 40px rgba(0,0,0,0.2);
+  overflow: hidden;
+}
+
+.pdf-picker-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px;
+  border-bottom: 1px solid #e5e7eb;
+  font-size: 14px;
+  font-weight: 700;
+  color: #1f2937;
+}
+.pdf-picker-header button {
+  background: none;
+  border: none;
+  font-size: 16px;
+  color: #6b7280;
+  cursor: pointer;
+  width: 28px;
+  height: 28px;
+}
+.pdf-picker-header button:hover { color: #1f2937; }
+
+.pdf-picker-empty {
+  padding: 32px 18px;
+  text-align: center;
+  color: #9ca3af;
+  font-size: 13px;
+  line-height: 1.7;
+}
+
+.pdf-picker-list {
+  list-style: none;
+  margin: 0;
+  padding: 8px;
+  overflow-y: auto;
+}
+
+.pdf-picker-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  border: 2px solid transparent;
+}
+.pdf-picker-item:hover { background: #f8fafc; border-color: #e2e8f0; }
+.pdf-picker-item.selected { background: #eff6ff; border-color: #3b82f6; }
+
+.pdf-picker-type-badge {
+  font-size: 10px;
+  font-weight: 700;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: #f1f5f9;
+  color: #475569;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.pdf-picker-filename {
+  flex: 1;
+  font-size: 13px;
+  font-weight: 500;
+  color: #1f2937;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pdf-picker-meta {
+  font-size: 11px;
+  color: #6b7280;
+  white-space: nowrap;
+}

--- a/child-learning-app/src/utils/testScores.js
+++ b/child-learning-app/src/utils/testScores.js
@@ -76,6 +76,9 @@ export async function addTestScore(userId, scoreData) {
       // メモ
       notes: scoreData.notes || '',
 
+      // 紐付けPDF
+      pdfDocumentId: scoreData.pdfDocumentId || null,
+
       createdAt: new Date().toISOString(),
     }
 


### PR DESCRIPTION
- PDFProblemView: アップロードフォームにPDF種類（テスト用紙/教材/過去問/問題集）を追加
- testScores: テスト成績にpdfDocumentIdフィールドを追加（テスト問題PDFの紐付け）
- TestScoreView: テスト詳細に「PDF紐付けバー」を追加
  - 登録済みPDFリストから選択して紐付け/変更/取り外しが可能
  - PDF_TYPE_LABELS定数でラベル表示
- PdfCropper: 3タブ構成に刷新
  - タブ1「紐付けPDF」: 紐付け済みPDFがあれば自動で開く（URL入力不要）
  - タブ2「登録済みから選択」: pdfDocumentsリストを検索・フィルタ付きで表示
  - タブ3「URLを入力」: 既存のDrive URL直接入力を維持

https://claude.ai/code/session_01TdzUBCnxia3ienbEbhZLfs