### PR TITLE
過去問に問題切り抜き機能を追加（Phase 1: problemsコレクション導入）

### DIFF
--- a/child-learning-app/src/components/PastPaperView.css
+++ b/child-learning-app/src/components/PastPaperView.css
@@ -1489,3 +1489,331 @@
     flex-direction: column;
   }
 }
+
+/* ─── 問題ログセクション ─────────────────────────────────── */
+
+.problem-log-section {
+  margin-top: 12px;
+  border-top: 1px dashed #e2e8f0;
+  padding-top: 10px;
+}
+
+.toggle-problems-btn {
+  background: none;
+  border: none;
+  color: #475569;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 4px 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.toggle-problems-btn:hover {
+  color: #1e40af;
+}
+
+.problem-count-badge {
+  background: #dbeafe;
+  color: #1e40af;
+  font-size: 0.75rem;
+  padding: 1px 7px;
+  border-radius: 12px;
+  font-weight: 600;
+}
+
+.problem-log-body {
+  margin-top: 10px;
+  padding: 12px;
+  background: #f8fafc;
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.no-problems-msg {
+  color: #94a3b8;
+  font-size: 0.82rem;
+  margin: 0;
+}
+
+/* 問題リスト */
+.problem-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.problem-item {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: white;
+  border: 1px solid #e2e8f0;
+}
+
+.problem-item.correct {
+  border-left: 3px solid #16a34a;
+}
+
+.problem-item.incorrect {
+  border-left: 3px solid #dc2626;
+}
+
+.problem-item-left {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  flex: 1;
+}
+
+.problem-item-right {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.problem-correctness {
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.problem-item.correct .problem-correctness { color: #16a34a; }
+.problem-item.incorrect .problem-correctness { color: #dc2626; }
+
+.problem-number {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #1e293b;
+}
+
+.problem-difficulty {
+  font-size: 0.75rem;
+  color: #f59e0b;
+}
+
+.problem-miss-type {
+  font-size: 0.72rem;
+  background: #fee2e2;
+  color: #dc2626;
+  padding: 1px 6px;
+  border-radius: 6px;
+}
+
+.problem-units {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.problem-thumbnail {
+  width: 60px;
+  height: 45px;
+  object-fit: cover;
+  border-radius: 4px;
+  border: 1px solid #e2e8f0;
+  cursor: pointer;
+}
+
+.problem-image-link {
+  display: inline-flex;
+}
+
+.review-status-select {
+  font-size: 0.75rem;
+  padding: 2px 6px;
+  border-radius: 8px;
+  border: 1px solid #e2e8f0;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.problem-delete-btn {
+  background: none;
+  border: none;
+  color: #94a3b8;
+  font-size: 1rem;
+  cursor: pointer;
+  padding: 0 2px;
+  line-height: 1;
+}
+.problem-delete-btn:hover { color: #dc2626; }
+
+/* 問題追加ボタン */
+.add-problem-btn {
+  align-self: flex-start;
+  background: none;
+  border: 1px dashed #94a3b8;
+  color: #64748b;
+  font-size: 0.82rem;
+  padding: 5px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.add-problem-btn:hover {
+  background: #f1f5f9;
+  border-color: #1e40af;
+  color: #1e40af;
+}
+
+/* 問題追加フォーム */
+.problem-form {
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.problem-form h4 {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #1e293b;
+}
+
+.problem-form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.problem-form-field label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #475569;
+}
+
+.problem-form-field input[type="text"] {
+  padding: 7px 10px;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  font-size: 0.85rem;
+}
+
+/* 正誤トグル */
+.correctness-toggle {
+  display: flex;
+  gap: 8px;
+}
+
+.correct-btn,
+.incorrect-btn {
+  flex: 1;
+  padding: 6px;
+  border-radius: 8px;
+  border: 2px solid #e2e8f0;
+  background: white;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.correct-btn.active {
+  border-color: #16a34a;
+  background: #dcfce7;
+  color: #16a34a;
+}
+
+.incorrect-btn.active {
+  border-color: #dc2626;
+  background: #fee2e2;
+  color: #dc2626;
+}
+
+/* ミスタイプ */
+.miss-type-btns {
+  display: flex;
+  gap: 6px;
+}
+
+.miss-type-btn {
+  flex: 1;
+  padding: 5px;
+  border-radius: 7px;
+  border: 1px solid #e2e8f0;
+  background: white;
+  font-size: 0.78rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.miss-type-btn.active {
+  border-color: #dc2626;
+  background: #fee2e2;
+  color: #dc2626;
+  font-weight: 600;
+}
+
+/* 難易度ボタン */
+.difficulty-btns {
+  display: flex;
+  gap: 6px;
+}
+
+.difficulty-btn {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 2px solid #e2e8f0;
+  background: white;
+  font-size: 0.82rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.difficulty-btn.active {
+  border-color: #f59e0b;
+  background: #fef3c7;
+  color: #b45309;
+}
+
+/* PDF切り抜きボタン */
+.crop-open-btn {
+  padding: 6px 14px;
+  background: #eff6ff;
+  color: #1e40af;
+  border: 1px solid #bfdbfe;
+  border-radius: 8px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.crop-open-btn:hover {
+  background: #dbeafe;
+}
+
+/* 画像プレビュー */
+.image-preview-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.problem-image-preview {
+  max-width: 160px;
+  max-height: 100px;
+  object-fit: cover;
+  border-radius: 6px;
+  border: 1px solid #e2e8f0;
+}
+
+/* フォームアクション */
+.problem-form-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}

--- a/child-learning-app/src/components/PastPaperView.jsx
+++ b/child-learning-app/src/components/PastPaperView.jsx
@@ -8,17 +8,45 @@ import {
   getNextAttemptNumber,
   deleteSessionsByTaskId
 } from '../utils/pastPaperSessions'
+import {
+  addProblem,
+  getProblemsBySource,
+  updateProblem,
+  deleteProblem,
+  deleteProblemsBySource,
+  reviewStatusInfo,
+  missTypeLabel,
+} from '../utils/problems'
 import { subjectColors, subjectEmojis } from '../utils/constants'
 import { toast } from '../utils/toast'
 import { uploadPDFToDrive, checkDriveAccess } from '../utils/googleDriveStorage'
 import { refreshGoogleAccessToken } from './Auth'
 import DriveFilePicker from './DriveFilePicker'
 import UnitTagPicker from './UnitTagPicker'
+import PdfCropper from './PdfCropper'
 
 const YEAR_OPTIONS = Array.from({ length: 2031 - 2000 }, (_, i) => 2000 + i)
 
 const EMPTY_ADD_FORM = { schoolName: '', year: '', subject: '算数', unitIds: [], fileUrl: '', fileName: '' }
 const EMPTY_EDIT_FORM = { schoolName: '', year: '', subject: '算数', unitIds: [], fileUrl: '', fileName: '' }
+
+const EMPTY_PROBLEM_FORM = {
+  problemNumber: '',
+  unitIds: [],
+  isCorrect: false,
+  missType: 'understanding',
+  difficulty: null,
+  imageUrl: null,
+}
+
+const DIFFICULTY_LABELS = { 1: '★', 2: '★★', 3: '★★★', 4: '★★★★', 5: '★★★★★' }
+
+/** Google Drive URL から driveFileId を抽出 */
+function extractDriveFileId(fileUrl) {
+  if (!fileUrl) return null
+  const match = fileUrl.match(/\/file\/d\/([^/?]+)/)
+  return match ? match[1] : null
+}
 
 // タスクの unitIds を正規化（旧 unitId との後方互換）
 const getTaskUnitIds = (task) =>
@@ -50,10 +78,85 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
   const addFileInputRef = useRef(null)
   const editFileInputRef = useRef(null)
 
+  // ── 問題ログ関連 ──────────────────────────────────────────
+  const [problems, setProblems] = useState({})           // taskId -> problems[]
+  const [expandedProblems, setExpandedProblems] = useState({}) // taskId -> boolean
+  const [showProblemForm, setShowProblemForm] = useState(null)  // taskId or null
+  const [problemForm, setProblemForm] = useState({ ...EMPTY_PROBLEM_FORM })
+  const [showPdfCropper, setShowPdfCropper] = useState(null)    // taskId or null
+
   // マスター単元を読み込み
   useEffect(() => {
     setMasterUnits(getStaticMasterUnits())
   }, [])
+
+  // ── 問題ログ読み込み ──────────────────────────────────────
+  const loadProblems = useCallback(async (taskId) => {
+    if (!user) return
+    const result = await getProblemsBySource(user.uid, 'pastPaper', taskId)
+    if (result.success) {
+      setProblems(prev => ({ ...prev, [taskId]: result.data }))
+    }
+  }, [user])
+
+  // 問題ログを追加
+  const handleAddProblem = async (task) => {
+    if (!problemForm.problemNumber.trim()) {
+      toast.error('問題番号を入力してください')
+      return
+    }
+    const result = await addProblem(user.uid, {
+      sourceType: 'pastPaper',
+      sourceId: task.id,
+      subject: task.subject,
+      problemNumber: problemForm.problemNumber.trim(),
+      unitIds: problemForm.unitIds,
+      isCorrect: problemForm.isCorrect,
+      missType: problemForm.isCorrect ? null : problemForm.missType,
+      difficulty: problemForm.difficulty,
+      imageUrl: problemForm.imageUrl,
+      schoolName: task.schoolName || null,
+      year: task.year || null,
+    })
+    if (result.success) {
+      await loadProblems(task.id)
+      setProblemForm({ ...EMPTY_PROBLEM_FORM })
+      setShowProblemForm(null)
+      toast.success('問題を追加しました')
+    } else {
+      toast.error('保存に失敗しました')
+    }
+  }
+
+  // 問題の reviewStatus を更新
+  const handleUpdateProblemStatus = async (taskId, problemId, reviewStatus) => {
+    await updateProblem(user.uid, problemId, { reviewStatus })
+    await loadProblems(taskId)
+  }
+
+  // 問題を削除
+  const handleDeleteProblem = async (taskId, problemId) => {
+    await deleteProblem(user.uid, problemId)
+    await loadProblems(taskId)
+    toast.success('削除しました')
+  }
+
+  // PDF切り抜き完了
+  const handlePdfCropComplete = (taskId) => (imageUrl) => {
+    setShowPdfCropper(null)
+    setProblemForm(prev => ({ ...prev, imageUrl }))
+    setShowProblemForm(taskId)
+    toast.success('問題画像を取り込みました。残りの情報を入力して追加してください。')
+  }
+
+  // 問題ログ展開時にデータ読み込み
+  const toggleProblemExpanded = async (taskId) => {
+    const next = !expandedProblems[taskId]
+    setExpandedProblems(prev => ({ ...prev, [taskId]: next }))
+    if (next && !problems[taskId]) {
+      await loadProblems(taskId)
+    }
+  }
 
   // PDF を Google Drive にアップロードする共通処理
   const handlePDFUpload = async (file, target) => {
@@ -251,6 +354,8 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
         toast.error('学習記録の削除に失敗しました: ' + sessionResult.error)
         return
       }
+      // 問題ログも削除
+      await deleteProblemsBySource(user.uid, 'pastPaper', taskId)
       await onDeleteTask(taskId)
       toast.success('過去問を削除しました')
     } catch (error) {
@@ -841,6 +946,275 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
                           + 学習記録を追加
                         </button>
                       ) : null}
+
+                      {/* ── 問題ログセクション ─────────────────────── */}
+                      {editingTaskId !== task.id && (
+                        <div className="problem-log-section">
+                          <button
+                            className="toggle-problems-btn"
+                            onClick={() => toggleProblemExpanded(task.id)}
+                          >
+                            {expandedProblems[task.id] ? '▼' : '▶'} 問題記録
+                            {problems[task.id]?.length > 0 && (
+                              <span className="problem-count-badge">
+                                {problems[task.id].length}問
+                              </span>
+                            )}
+                          </button>
+
+                          {expandedProblems[task.id] && (
+                            <div className="problem-log-body">
+                              {/* 問題一覧 */}
+                              {(problems[task.id] || []).length === 0 ? (
+                                <p className="no-problems-msg">まだ問題が記録されていません</p>
+                              ) : (
+                                <div className="problem-list">
+                                  {(problems[task.id] || []).map(problem => {
+                                    const st = reviewStatusInfo(problem.reviewStatus)
+                                    return (
+                                      <div
+                                        key={problem.firestoreId}
+                                        className={`problem-item ${problem.isCorrect ? 'correct' : 'incorrect'}`}
+                                      >
+                                        <div className="problem-item-left">
+                                          <span className="problem-correctness">
+                                            {problem.isCorrect ? '○' : '✗'}
+                                          </span>
+                                          <span className="problem-number">
+                                            第{problem.problemNumber}問
+                                          </span>
+                                          {problem.difficulty && (
+                                            <span className="problem-difficulty">
+                                              {DIFFICULTY_LABELS[problem.difficulty]}
+                                            </span>
+                                          )}
+                                          {!problem.isCorrect && problem.missType && (
+                                            <span className="problem-miss-type">
+                                              {missTypeLabel(problem.missType)}
+                                            </span>
+                                          )}
+                                          {problem.unitIds?.length > 0 && (
+                                            <div className="problem-units">
+                                              {problem.unitIds.map(id => (
+                                                <span key={id} className="unit-tag">
+                                                  {getUnitName(id)}
+                                                </span>
+                                              ))}
+                                            </div>
+                                          )}
+                                          {problem.imageUrl && (
+                                            <a
+                                              href={problem.imageUrl}
+                                              target="_blank"
+                                              rel="noopener noreferrer"
+                                              className="problem-image-link"
+                                            >
+                                              <img
+                                                src={problem.imageUrl}
+                                                alt="問題画像"
+                                                className="problem-thumbnail"
+                                              />
+                                            </a>
+                                          )}
+                                        </div>
+                                        <div className="problem-item-right">
+                                          {!problem.isCorrect && (
+                                            <select
+                                              className="review-status-select"
+                                              value={problem.reviewStatus}
+                                              style={{ background: st.bg, color: st.color }}
+                                              onChange={(e) =>
+                                                handleUpdateProblemStatus(task.id, problem.firestoreId, e.target.value)
+                                              }
+                                            >
+                                              <option value="pending">未完了</option>
+                                              <option value="retry">要再挑戦</option>
+                                              <option value="done">解き直し済</option>
+                                            </select>
+                                          )}
+                                          <button
+                                            className="problem-delete-btn"
+                                            onClick={() => handleDeleteProblem(task.id, problem.firestoreId)}
+                                            title="削除"
+                                          >
+                                            ×
+                                          </button>
+                                        </div>
+                                      </div>
+                                    )
+                                  })}
+                                </div>
+                              )}
+
+                              {/* 問題追加フォーム */}
+                              {showProblemForm === task.id ? (
+                                <div className="problem-form">
+                                  <h4>問題を追加</h4>
+
+                                  {/* 問題番号 */}
+                                  <div className="problem-form-field">
+                                    <label>問題番号:</label>
+                                    <input
+                                      type="text"
+                                      placeholder="例: 1, 2(1), 大問3"
+                                      value={problemForm.problemNumber}
+                                      onChange={(e) =>
+                                        setProblemForm(prev => ({ ...prev, problemNumber: e.target.value }))
+                                      }
+                                    />
+                                  </div>
+
+                                  {/* 正誤 */}
+                                  <div className="problem-form-field">
+                                    <label>正誤:</label>
+                                    <div className="correctness-toggle">
+                                      <button
+                                        type="button"
+                                        className={`correct-btn ${problemForm.isCorrect ? 'active' : ''}`}
+                                        onClick={() => setProblemForm(prev => ({ ...prev, isCorrect: true }))}
+                                      >
+                                        ○ 正解
+                                      </button>
+                                      <button
+                                        type="button"
+                                        className={`incorrect-btn ${!problemForm.isCorrect ? 'active' : ''}`}
+                                        onClick={() => setProblemForm(prev => ({ ...prev, isCorrect: false }))}
+                                      >
+                                        ✗ 不正解
+                                      </button>
+                                    </div>
+                                  </div>
+
+                                  {/* ミスタイプ（不正解時のみ） */}
+                                  {!problemForm.isCorrect && (
+                                    <div className="problem-form-field">
+                                      <label>ミスの種類:</label>
+                                      <div className="miss-type-btns">
+                                        {[
+                                          { value: 'understanding', label: '理解不足' },
+                                          { value: 'careless',      label: 'ケアレス' },
+                                          { value: 'not_studied',   label: '未習' },
+                                        ].map(opt => (
+                                          <button
+                                            key={opt.value}
+                                            type="button"
+                                            className={`miss-type-btn ${problemForm.missType === opt.value ? 'active' : ''}`}
+                                            onClick={() =>
+                                              setProblemForm(prev => ({ ...prev, missType: opt.value }))
+                                            }
+                                          >
+                                            {opt.label}
+                                          </button>
+                                        ))}
+                                      </div>
+                                    </div>
+                                  )}
+
+                                  {/* 難易度 */}
+                                  <div className="problem-form-field">
+                                    <label>難易度（任意）:</label>
+                                    <div className="difficulty-btns">
+                                      {[1, 2, 3, 4, 5].map(d => (
+                                        <button
+                                          key={d}
+                                          type="button"
+                                          className={`difficulty-btn ${problemForm.difficulty === d ? 'active' : ''}`}
+                                          onClick={() =>
+                                            setProblemForm(prev => ({
+                                              ...prev,
+                                              difficulty: prev.difficulty === d ? null : d
+                                            }))
+                                          }
+                                        >
+                                          {d}
+                                        </button>
+                                      ))}
+                                    </div>
+                                  </div>
+
+                                  {/* 単元タグ */}
+                                  <div className="problem-form-field">
+                                    <label>単元タグ（任意）:</label>
+                                    <UnitTagPicker
+                                      subject={task.subject}
+                                      value={problemForm.unitIds}
+                                      onChange={(unitIds) =>
+                                        setProblemForm(prev => ({ ...prev, unitIds }))
+                                      }
+                                    />
+                                  </div>
+
+                                  {/* 問題画像 */}
+                                  <div className="problem-form-field">
+                                    <label>問題画像（任意）:</label>
+                                    {problemForm.imageUrl ? (
+                                      <div className="image-preview-row">
+                                        <img
+                                          src={problemForm.imageUrl}
+                                          alt="問題プレビュー"
+                                          className="problem-image-preview"
+                                        />
+                                        <button
+                                          type="button"
+                                          className="btn-secondary"
+                                          onClick={() =>
+                                            setProblemForm(prev => ({ ...prev, imageUrl: null }))
+                                          }
+                                        >
+                                          削除
+                                        </button>
+                                      </div>
+                                    ) : (
+                                      <button
+                                        type="button"
+                                        className="crop-open-btn"
+                                        onClick={() => {
+                                          setShowProblemForm(null)
+                                          setShowPdfCropper(task.id)
+                                        }}
+                                      >
+                                        ✂ PDFから切り抜く
+                                      </button>
+                                    )}
+                                  </div>
+
+                                  <div className="problem-form-actions">
+                                    <button
+                                      className="btn-secondary"
+                                      onClick={() => {
+                                        setShowProblemForm(null)
+                                        setProblemForm({ ...EMPTY_PROBLEM_FORM })
+                                      }}
+                                    >
+                                      キャンセル
+                                    </button>
+                                    <button
+                                      className="btn-primary"
+                                      onClick={() => handleAddProblem(task)}
+                                    >
+                                      ✓ 追加する
+                                    </button>
+                                  </div>
+                                </div>
+                              ) : (
+                                <button
+                                  className="add-problem-btn"
+                                  onClick={() => {
+                                    setProblemForm({
+                                      ...EMPTY_PROBLEM_FORM,
+                                      unitIds: getTaskUnitIds(task),
+                                    })
+                                    setShowProblemForm(task.id)
+                                  }}
+                                >
+                                  + 問題を追加
+                                </button>
+                              )}
+                            </div>
+                          )}
+                        </div>
+                      )}
+                      {/* ─────────────────────────────────────────────── */}
                     </div>
                   )
                 })}
@@ -897,6 +1271,26 @@ function PastPaperView({ tasks, user, customUnits = [], onAddTask, onUpdateTask,
           onClose={() => setShowDrivePicker(null)}
         />
       )}
+
+      {/* PDF切り抜きモーダル */}
+      {showPdfCropper && (() => {
+        const cropTask = pastPaperTasks.find(t => t.id === showPdfCropper)
+        const driveFileId = cropTask ? extractDriveFileId(cropTask.fileUrl) : null
+        const attachedPdf = driveFileId
+          ? { driveFileId, fileName: cropTask.fileName || cropTask.title, firestoreId: null }
+          : null
+        return (
+          <PdfCropper
+            userId={user.uid}
+            attachedPdf={attachedPdf}
+            onCropComplete={handlePdfCropComplete(showPdfCropper)}
+            onClose={() => {
+              setShowPdfCropper(null)
+              setShowProblemForm(showPdfCropper)
+            }}
+          />
+        )
+      })()}
     </div>
   )
 }

--- a/child-learning-app/src/utils/problems.js
+++ b/child-learning-app/src/utils/problems.js
@@ -1,0 +1,164 @@
+// 問題ライブラリ管理（Firestore: users/{userId}/problems）
+//
+// sourceType ごとの用途:
+//   'pastPaper' - 過去問タスクから切り抜いた問題（sourceId = taskId）
+//   'test'      - テスト用紙から切り抜いた問題（sourceId = testScoreId）
+//   'textbook'  - 教材から切り抜いた問題（sourceId = lessonLogId）
+
+import {
+  collection,
+  addDoc,
+  getDocs,
+  doc,
+  updateDoc,
+  deleteDoc,
+  query,
+  where,
+  orderBy,
+  serverTimestamp,
+} from 'firebase/firestore'
+import { db } from '../firebase'
+
+/**
+ * 問題を追加
+ * @param {string} userId
+ * @param {object} problemData
+ * @param {string} problemData.sourceType - 'pastPaper' | 'test' | 'textbook'
+ * @param {string} problemData.sourceId   - taskId / testScoreId / lessonLogId
+ * @param {string} problemData.subject
+ * @param {string} problemData.problemNumber
+ * @param {string[]} problemData.unitIds
+ * @param {boolean} problemData.isCorrect
+ * @param {string|null} problemData.missType - 'understanding'|'careless'|'not_studied'|null
+ * @param {number|null} problemData.difficulty - 1〜5（過去問のみ）
+ * @param {string|null} problemData.imageUrl
+ * @param {string|null} problemData.schoolName - 過去問のみ
+ * @param {string|null} problemData.year       - 過去問のみ
+ * @param {number|null} problemData.correctRate - テストのみ（全体正答率 %）
+ * @param {number|null} problemData.points      - テストのみ
+ */
+export async function addProblem(userId, problemData) {
+  try {
+    const ref = collection(db, 'users', userId, 'problems')
+    const doc_ = {
+      sourceType: problemData.sourceType,
+      sourceId: problemData.sourceId,
+      subject: problemData.subject || '',
+      problemNumber: problemData.problemNumber || '',
+      unitIds: problemData.unitIds || [],
+      isCorrect: problemData.isCorrect ?? false,
+      missType: problemData.isCorrect ? null : (problemData.missType || 'understanding'),
+      reviewStatus: 'pending',
+      difficulty: problemData.difficulty || null,
+      imageUrl: problemData.imageUrl || null,
+      // 過去問メタデータ
+      schoolName: problemData.schoolName || null,
+      year: problemData.year || null,
+      // テストメタデータ
+      correctRate: problemData.correctRate ?? null,
+      points: problemData.points ?? null,
+      createdAt: serverTimestamp(),
+    }
+    const docRef = await addDoc(ref, doc_)
+    return { success: true, data: { firestoreId: docRef.id, ...doc_ } }
+  } catch (error) {
+    console.error('Error adding problem:', error)
+    return { success: false, error: error.message }
+  }
+}
+
+/**
+ * sourceType + sourceId に紐づく問題一覧を取得
+ * @param {string} userId
+ * @param {string} sourceType - 'pastPaper' | 'test' | 'textbook'
+ * @param {string} sourceId
+ */
+export async function getProblemsBySource(userId, sourceType, sourceId) {
+  try {
+    const ref = collection(db, 'users', userId, 'problems')
+    const q = query(
+      ref,
+      where('sourceType', '==', sourceType),
+      where('sourceId', '==', sourceId),
+      orderBy('createdAt', 'asc')
+    )
+    const snapshot = await getDocs(q)
+    const problems = []
+    snapshot.forEach(d => problems.push({ firestoreId: d.id, ...d.data() }))
+    return { success: true, data: problems }
+  } catch (error) {
+    console.error('Error getting problems:', error)
+    return { success: false, error: error.message, data: [] }
+  }
+}
+
+/**
+ * 問題を更新（reviewStatus・missType 等）
+ * @param {string} userId
+ * @param {string} problemId - Firestore ドキュメント ID
+ * @param {object} updates
+ */
+export async function updateProblem(userId, problemId, updates) {
+  try {
+    const ref = doc(db, 'users', userId, 'problems', problemId)
+    await updateDoc(ref, { ...updates, updatedAt: serverTimestamp() })
+    return { success: true }
+  } catch (error) {
+    console.error('Error updating problem:', error)
+    return { success: false, error: error.message }
+  }
+}
+
+/**
+ * 問題を削除
+ * @param {string} userId
+ * @param {string} problemId - Firestore ドキュメント ID
+ */
+export async function deleteProblem(userId, problemId) {
+  try {
+    const ref = doc(db, 'users', userId, 'problems', problemId)
+    await deleteDoc(ref)
+    return { success: true }
+  } catch (error) {
+    console.error('Error deleting problem:', error)
+    return { success: false, error: error.message }
+  }
+}
+
+/**
+ * sourceType + sourceId に紐づく問題をすべて削除
+ * （タスクや単元ログ削除時に呼ぶ）
+ * @param {string} userId
+ * @param {string} sourceType
+ * @param {string} sourceId
+ */
+export async function deleteProblemsBySource(userId, sourceType, sourceId) {
+  try {
+    const result = await getProblemsBySource(userId, sourceType, sourceId)
+    if (!result.success) return result
+    await Promise.all(
+      result.data.map(p => deleteProblem(userId, p.firestoreId))
+    )
+    return { success: true, deletedCount: result.data.length }
+  } catch (error) {
+    console.error('Error deleting problems by source:', error)
+    return { success: false, error: error.message }
+  }
+}
+
+// ─── ヘルパー ───────────────────────────────────────────
+
+/** reviewStatus の表示情報 */
+export function reviewStatusInfo(status) {
+  if (status === 'done')  return { label: '解き直し済', color: '#16a34a', bg: '#dcfce7' }
+  if (status === 'retry') return { label: '要再挑戦',   color: '#dc2626', bg: '#fee2e2' }
+  return                         { label: '未完了',     color: '#64748b', bg: '#f1f5f9' }
+}
+
+/** missType の日本語ラベル */
+export function missTypeLabel(type) {
+  if (type === 'understanding') return '理解不足'
+  if (type === 'careless')      return 'ケアレス'
+  if (type === 'not_studied')   return '未習'
+  return ''
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -114,6 +114,12 @@ service cloud.firestore {
       match /masterUnitStats/{unitId} {
         allow read, write: if isAuthenticated() && isOwner(userId);
       }
+
+      // 問題ライブラリ（切り抜き問題）コレクション
+      // テスト・過去問・教材から切り抜いた問題画像と記録を管理
+      match /problems/{problemId} {
+        allow read, write: if isAuthenticated() && isOwner(userId);
+      }
     }
 
     // その他のすべてのドキュメントへのアクセスを拒否


### PR DESCRIPTION
- Firestore rules: users/{userId}/problems サブコレクションを追加 テスト・過去問・教材の切り抜き問題を管理する統一コレクション

- src/utils/problems.js 新規作成 addProblem / getProblemsBySource / updateProblem / deleteProblem / deleteProblemsBySource の CRUD 関数群 sourceType: 'pastPaper' | 'test' | 'textbook' で用途を分離

- PastPaperView: 問題ログ機能 + PdfCropper を追加 各過去問タスクカードに問題記録セクションを追加
  - 問題番号・正誤・ミスタイプ・難易度・単元タグ・画像の記録
  - PdfCropper から問題画像を切り抜いて添付可能
  - 解き直し状況（pending / retry / done）を管理
  - タスク削除時に紐づく問題も自動削除

https://claude.ai/code/session_01TdzUBCnxia3ienbEbhZLfs