### PR TITLE
fix: PdfCropperの科目タブがPCで見えない問題を修正＋モーダルを大幅に拡大

### DIFF
--- a/child-learning-app/src/components/PdfCropper.css
+++ b/child-learning-app/src/components/PdfCropper.css
@@ -5,18 +5,19 @@
   background: rgba(0, 0, 0, 0.6);
   z-index: 2000;
   display: flex;
-  align-items: flex-start;
+  align-items: stretch;
   justify-content: center;
-  padding: 20px;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch; /* iOS でのスムーズスクロール */
+  padding: 12px;
+  overflow: hidden;
+  -webkit-overflow-scrolling: touch;
 }
 
 .pdfcropper-modal {
   background: white;
-  border-radius: 16px;
+  border-radius: 12px;
   width: 100%;
-  max-width: 860px;
+  max-width: 1200px;
+  max-height: 100%;
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
   display: flex;
   flex-direction: column;
@@ -235,17 +236,18 @@
   text-align: center;
 }
 
-/* Canvas エリア */
+/* Canvas エリア — flex-growでモーダル内の残り高さを全て使う */
 .pdfcropper-canvas-wrapper {
   position: relative;
   overflow: auto;
-  max-height: 420px;
+  flex: 1 1 0;
+  min-height: 200px;
   background: #e5e7eb;
   display: flex;
   justify-content: center;
   align-items: flex-start;
   padding: 10px;
-  -webkit-overflow-scrolling: touch; /* iOS でのスムーズスクロール */
+  -webkit-overflow-scrolling: touch;
 }
 
 .pdfcropper-canvas {
@@ -449,7 +451,8 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
-  max-height: 340px;
+  flex: 1 1 0;
+  min-height: 0;
   overflow-y: auto;
 }
 
@@ -515,9 +518,20 @@
 /* レスポンシブ */
 @media (max-width: 640px) {
   .pdfcropper-overlay {
-    padding: 10px;
+    padding: 0;
   }
-  .pdfcropper-canvas-wrapper {
-    max-height: 320px;
+  .pdfcropper-modal {
+    border-radius: 0;
+    max-width: 100%;
+  }
+  .pdfcropper-header {
+    padding: 10px 14px;
+  }
+  .pdfcropper-controls {
+    padding: 8px 10px;
+    gap: 8px;
+  }
+  .pdfcropper-preview-area {
+    padding: 10px 14px;
   }
 }

--- a/child-learning-app/src/components/PdfCropper.jsx
+++ b/child-learning-app/src/components/PdfCropper.jsx
@@ -17,7 +17,7 @@ pdfjsLib.GlobalWorkerOptions.workerSrc =
 //   onClose       : () => void
 // ─────────────────────────────────────────
 
-export default function PdfCropper({ userId, attachedPdf, onCropComplete, onClose }) {
+export default function PdfCropper({ userId, attachedPdf, onCropComplete, onClose, headerSlot }) {
   // アクティブタブ: 'attached' | 'list' | 'url'
   const defaultTab = attachedPdf ? 'attached' : 'list'
   const [activeTab, setActiveTab] = useState(defaultTab)
@@ -323,6 +323,9 @@ export default function PdfCropper({ userId, attachedPdf, onCropComplete, onClos
   return (
     <div className="pdfcropper-overlay" onClick={onClose}>
       <div className="pdfcropper-modal" onClick={e => e.stopPropagation()}>
+
+        {/* 呼び出し元から注入されるヘッダースロット（科目タブなど） */}
+        {headerSlot}
 
         {/* ヘッダー */}
         <div className="pdfcropper-header">

--- a/child-learning-app/src/components/TestScoreView.css
+++ b/child-learning-app/src/components/TestScoreView.css
@@ -1661,17 +1661,13 @@
 }
 .pdf-attach-remove:hover { color: #dc2626; }
 
-/* PdfCropper 科目切り替えタブ */
+/* PdfCropper 科目切り替えタブ（モーダル内に配置） */
 .pdf-cropper-subject-tabs {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
   display: flex;
   gap: 0;
   background: #1e293b;
   padding: 6px 12px 0;
-  z-index: 2100;
+  flex-shrink: 0;
 }
 
 .pdf-cropper-subject-tab {
@@ -1696,11 +1692,6 @@
 .pdf-cropper-subject-tab.no-pdf {
   opacity: 0.4;
   cursor: not-allowed;
-}
-
-/* PdfCropper のオーバーレイにタブ分の余白を追加 */
-.pdf-cropper-subject-tabs ~ .pdfcropper-overlay {
-  padding-top: 50px;
 }
 
 /* PDFピッカーモーダル */

--- a/child-learning-app/src/components/TestScoreView.jsx
+++ b/child-learning-app/src/components/TestScoreView.jsx
@@ -939,37 +939,36 @@ function TestScoreView({ user }) {
       )}
 
       {showPdfCropper && (
-        <>
-          {/* 科目切り替えタブ（PdfCropperオーバーレイの上にfixed表示） */}
-          <div className="pdf-cropper-subject-tabs">
-            {SUBJECTS.map(subject => {
-              const hasPdf = !!getPdfForSubject(subject)
-              return (
-                <button
-                  key={subject}
-                  className={`pdf-cropper-subject-tab ${showPdfCropper === subject ? 'active' : ''} ${!hasPdf ? 'no-pdf' : ''}`}
-                  onClick={() => hasPdf && setShowPdfCropper(subject)}
-                  disabled={!hasPdf}
-                  title={hasPdf ? `${subject}のPDFから切り出す` : `${subject}のPDFが未添付です`}
-                >
-                  {subject}{!hasPdf && '（未添付）'}
-                </button>
-              )
-            })}
-          </div>
-          <PdfCropper
-            key={showPdfCropper}
-            userId={user.uid}
-            attachedPdf={(() => {
-              const pdf = getPdfForSubject(showPdfCropper)
-              if (!pdf) return null
-              const driveFileId = extractDriveFileId(pdf.fileUrl)
-              return driveFileId ? { driveFileId, fileName: pdf.fileName, firestoreId: null } : null
-            })()}
-            onCropComplete={handlePdfCropComplete}
-            onClose={() => setShowPdfCropper(null)}
-          />
-        </>
+        <PdfCropper
+          key={showPdfCropper}
+          userId={user.uid}
+          attachedPdf={(() => {
+            const pdf = getPdfForSubject(showPdfCropper)
+            if (!pdf) return null
+            const driveFileId = extractDriveFileId(pdf.fileUrl)
+            return driveFileId ? { driveFileId, fileName: pdf.fileName, firestoreId: null } : null
+          })()}
+          onCropComplete={handlePdfCropComplete}
+          onClose={() => setShowPdfCropper(null)}
+          headerSlot={
+            <div className="pdf-cropper-subject-tabs">
+              {SUBJECTS.map(subject => {
+                const hasPdf = !!getPdfForSubject(subject)
+                return (
+                  <button
+                    key={subject}
+                    className={`pdf-cropper-subject-tab ${showPdfCropper === subject ? 'active' : ''} ${!hasPdf ? 'no-pdf' : ''}`}
+                    onClick={() => hasPdf && setShowPdfCropper(subject)}
+                    disabled={!hasPdf}
+                    title={hasPdf ? `${subject}のPDFから切り出す` : `${subject}のPDFが未添付です`}
+                  >
+                    {subject}{!hasPdf && '（未添付）'}
+                  </button>
+                )
+              })}
+            </div>
+          }
+        />
       )}
     </div>
   )


### PR DESCRIPTION
科目タブの修正:
- position:fixedの兄弟要素からheaderSlot propsでモーダル内部に統合
- PCでもiPhoneでも同一のモーダル内に科目タブが表示される

モーダルサイズの拡大:
- max-width: 860px → 1200pxに拡大
- overlayをalign-items:stretchにしてモーダルがビューポート高さ一杯に
- キャンバスラッパーをflex:1にして残り高さ全てを使用(max-height:420px廃止)
- PDFリストもflex:1で残り高さを活用
- モバイル(640px以下): padding:0、border-radius:0で完全フルスクリーン

https://claude.ai/code/session_01TdzUBCnxia3ienbEbhZLfs