### PR TITLE
feat: PdfCropperのタッチ/マウス操作を直感的なマルチジェスチャーに刷新

### DIFF
--- a/child-learning-app/src/components/PdfCropper.css
+++ b/child-learning-app/src/components/PdfCropper.css
@@ -188,52 +188,10 @@
 }
 
 .pdfcropper-hint {
-  font-size: 12px;
+  font-size: 11px;
   color: #6b7280;
   margin-left: auto;
-}
-
-/* モード切り替えボタン */
-.pdfcropper-mode-btn {
-  padding: 6px 14px;
-  border-radius: 20px;
-  border: 2px solid;
-  font-size: 12px;
-  font-weight: 700;
-  cursor: pointer;
   white-space: nowrap;
-  transition: all 0.15s;
-}
-.pdfcropper-mode-btn.pan {
-  background: white;
-  border-color: #6b7280;
-  color: #374151;
-}
-.pdfcropper-mode-btn.pan:hover {
-  border-color: #10b981;
-  color: #059669;
-  background: #f0fdf4;
-}
-.pdfcropper-mode-btn.select {
-  background: #10b981;
-  border-color: #10b981;
-  color: white;
-}
-.pdfcropper-mode-btn.select:hover {
-  background: #059669;
-  border-color: #059669;
-}
-
-/* 切り出しモード中のガイドバナー */
-.pdfcropper-select-banner {
-  padding: 8px 16px;
-  background: #ecfdf5;
-  border-top: 1px solid #a7f3d0;
-  border-bottom: 1px solid #a7f3d0;
-  font-size: 13px;
-  color: #065f46;
-  font-weight: 600;
-  text-align: center;
 }
 
 /* Canvas エリア — flex-growでモーダル内の残り高さを全て使う */
@@ -261,17 +219,7 @@
   left: 50%;
   transform: translateX(-50%);
   cursor: crosshair;
-}
-/* パンモード: タッチ・マウスイベントを下の要素に透過 */
-.pdfcropper-overlay-canvas.pan-mode {
-  pointer-events: none;
-  cursor: default;
-}
-/* 切り出しモード: タッチ操作を全てJSで処理 */
-.pdfcropper-overlay-canvas.select-active {
-  pointer-events: auto;
-  cursor: crosshair;
-  touch-action: none;
+  touch-action: none; /* タッチジェスチャーを全てJSで処理 */
 }
 
 /* プレビュー */


### PR DESCRIPTION
iPhone (タッチ):
- 1本指ドラッグ → 切り出し範囲選択
- 2本指ドラッグ → キャンバスパン（スクロール）
- 2本指ピンチ → ズーム

PC (マウス):
- 左クリックドラッグ → 切り出し範囲選択
- 中ボタンドラッグ → キャンバスパン
- ホイール → ズーム

変更内容:
- selectModeトグルボタンを廃止（操作方法で自動判別）
- タッチイベントで2本指の距離変化でピンチ判定、中心移動でパン判定
- マウスイベントでe.button判定（0=左、1=中）
- ホイールイベントでズーム制御
- ガイドをコンパクト化: "📱 1本指=切出 / 2本指=パン・ピンチ..."

https://claude.ai/code/session_01TdzUBCnxia3ienbEbhZLfs