### PR TITLE
fix: PCでのパン操作が左端まで到達しない問題を修正

### DIFF
--- a/child-learning-app/src/components/PdfCropper.css
+++ b/child-learning-app/src/components/PdfCropper.css
@@ -201,11 +201,13 @@
   flex: 1 1 0;
   min-height: 200px;
   background: #e5e7eb;
-  display: flex;
-  justify-content: center;
-  align-items: flex-start;
   padding: 10px;
   -webkit-overflow-scrolling: touch;
+}
+
+.pdfcropper-canvas-container {
+  position: relative;
+  display: inline-block;
 }
 
 .pdfcropper-canvas {
@@ -215,9 +217,8 @@
 
 .pdfcropper-overlay-canvas {
   position: absolute;
-  top: 10px;
-  left: 50%;
-  transform: translateX(-50%);
+  top: 0;
+  left: 0;
   cursor: crosshair;
   touch-action: none; /* タッチジェスチャーを全てJSで処理 */
 }

--- a/child-learning-app/src/components/PdfCropper.jsx
+++ b/child-learning-app/src/components/PdfCropper.jsx
@@ -250,6 +250,7 @@ export default function PdfCropper({ userId, attachedPdf, onCropComplete, onClos
     } else if (isPanningRef.current && panStartRef.current && canvasWrapperRef.current) {
       const dx = e.clientX - panStartRef.current.x
       const dy = e.clientY - panStartRef.current.y
+      // マウスを右に動かすとdxが正 → scrollLeftを減らして左へスクロール
       canvasWrapperRef.current.scrollLeft = panStartRef.current.scrollLeft - dx
       canvasWrapperRef.current.scrollTop = panStartRef.current.scrollTop - dy
     }
@@ -579,16 +580,18 @@ export default function PdfCropper({ userId, attachedPdf, onCropComplete, onClos
               className="pdfcropper-canvas-wrapper"
               onWheel={handleWheel}
             >
-              <canvas ref={canvasRef} className="pdfcropper-canvas" />
-              <canvas
-                ref={overlayRef}
-                className="pdfcropper-overlay-canvas"
-                onMouseDown={handleMouseDown}
-                onMouseMove={handleMouseMove}
-                onMouseUp={handleMouseUp}
-                onMouseLeave={handleMouseUp}
-                onContextMenu={(e) => e.preventDefault()}
-              />
+              <div className="pdfcropper-canvas-container">
+                <canvas ref={canvasRef} className="pdfcropper-canvas" />
+                <canvas
+                  ref={overlayRef}
+                  className="pdfcropper-overlay-canvas"
+                  onMouseDown={handleMouseDown}
+                  onMouseMove={handleMouseMove}
+                  onMouseUp={handleMouseUp}
+                  onMouseLeave={handleMouseUp}
+                  onContextMenu={(e) => e.preventDefault()}
+                />
+              </div>
             </div>
 
             {croppedPreview && (


### PR DESCRIPTION
問題:
- canvas-wrapperがdisplay:flex + justify-content:centerだったため canvasが常に中央配置され、スクロールバーが発生しなかった
- overlayがtransform:translateX(-50%)で中央寄せされていた

修正:
- canvas-wrapperからflex中央配置を削除
- canvas-containerを追加してcanvasとoverlayを包含
- overlayをposition:absolute + top:0/left:0でcanvasに完全重ね合わせ
- inline-blockでコンテナがcanvasサイズに追従し、スクロール可能に

https://claude.ai/code/session_01TdzUBCnxia3ienbEbhZLfs