### PR TITLE
fix: 国語の単元が選択できない問題を修正 + ズームUIを改善

### DIFF
--- a/child-learning-app/src/components/PdfCropper.css
+++ b/child-learning-app/src/components/PdfCropper.css
@@ -160,15 +160,32 @@
 .pdfcropper-zoom {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 4px;
+}
+
+.pdfcropper-zoom-fit,
+.pdfcropper-zoom-reset {
+  padding: 4px 10px;
   border: 1px solid #d1d5db;
   border-radius: 6px;
-  overflow: hidden;
+  background: white;
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 600;
+  color: #374151;
+  white-space: nowrap;
 }
-.pdfcropper-zoom button {
+.pdfcropper-zoom-fit:hover,
+.pdfcropper-zoom-reset:hover {
+  background: #eff6ff;
+  border-color: #3b82f6;
+}
+
+.pdfcropper-zoom-btn {
   width: 28px;
   height: 28px;
-  border: none;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
   background: white;
   cursor: pointer;
   font-size: 16px;
@@ -176,14 +193,16 @@
   align-items: center;
   justify-content: center;
 }
-.pdfcropper-zoom button:hover {
+.pdfcropper-zoom-btn:hover {
   background: #eff6ff;
+  border-color: #3b82f6;
 }
-.pdfcropper-zoom span {
+
+.pdfcropper-zoom-display {
   font-size: 12px;
   font-weight: 600;
   color: #374151;
-  min-width: 38px;
+  min-width: 42px;
   text-align: center;
 }
 

--- a/child-learning-app/src/components/PdfCropper.jsx
+++ b/child-learning-app/src/components/PdfCropper.jsx
@@ -566,9 +566,43 @@ export default function PdfCropper({ userId, attachedPdf, onCropComplete, onClos
                 >→</button>
               </div>
               <div className="pdfcropper-zoom">
-                <button onClick={() => setScale(s => Math.max(0.5, Math.round((s - 0.25) * 100) / 100))}>−</button>
-                <span>{Math.round(scale * 100)}%</span>
-                <button onClick={() => setScale(s => Math.min(3, Math.round((s + 0.25) * 100) / 100))}>＋</button>
+                <button
+                  className="pdfcropper-zoom-fit"
+                  onClick={() => {
+                    // キャンバスをwrapper幅に合わせる
+                    if (canvasRef.current && canvasWrapperRef.current) {
+                      const wrapperWidth = canvasWrapperRef.current.clientWidth - 20 // padding分を引く
+                      const canvasWidth = canvasRef.current.width
+                      const fitScale = wrapperWidth / canvasWidth
+                      setScale(Math.max(0.5, Math.min(3, Math.round(fitScale * 100) / 100)))
+                    }
+                  }}
+                  title="ページ幅に合わせる"
+                >
+                  幅に合わせる
+                </button>
+                <button
+                  className="pdfcropper-zoom-reset"
+                  onClick={() => setScale(1.0)}
+                  title="100%に戻す"
+                >
+                  100%
+                </button>
+                <button
+                  className="pdfcropper-zoom-btn"
+                  onClick={() => setScale(s => Math.max(0.5, Math.round((s - 0.1) * 10) / 10))}
+                  title="縮小"
+                >
+                  −
+                </button>
+                <span className="pdfcropper-zoom-display">{Math.round(scale * 100)}%</span>
+                <button
+                  className="pdfcropper-zoom-btn"
+                  onClick={() => setScale(s => Math.min(3, Math.round((s + 0.1) * 10) / 10))}
+                  title="拡大"
+                >
+                  ＋
+                </button>
               </div>
               <span className="pdfcropper-hint">
                 📱 1本指=切出 / 2本指=パン・ピンチ　🖱️ 左=切出 / 中=パン / ホイール=ズーム

--- a/child-learning-app/src/components/TestScoreView.jsx
+++ b/child-learning-app/src/components/TestScoreView.jsx
@@ -119,7 +119,7 @@ function TestScoreView({ user }) {
   }
 
   function getUnitsForSubject(subject) {
-    return masterUnits.filter(u => !u.subject || u.subject === subject)
+    return masterUnits.filter(u => u.subject === subject)
   }
 
   // 科目別PDF: { subject: { fileUrl, fileName } }


### PR DESCRIPTION
問題1: 国語の単元が表示されない
原因: getUnitsForSubjectの条件に不要な`!u.subject`が残っていた
  → レガシーコード（subjectフィールドがない古いデータ互換）
  → 現在は全単元にsubjectが付与されているため不要
修正: `u.subject === subject` のみに修正

問題2: ズームが100%に戻らない
原因: ±0.25の固定ステップで、中間値に留まる（例: 1.0→1.25→1.5）
修正: 一般的なPDFビューアUIを採用
  - [幅に合わせる] ボタン: wrapper幅にauto-fit
  - [100%] ボタン: 1.0倍にワンクリックリセット
  - [−][＋] ボタン: 0.1刻みで微調整（0.5〜3.0倍）
  - 倍率表示: 現在の拡大率を表示

https://claude.ai/code/session_01TdzUBCnxia3ienbEbhZLfs