### PR TITLE
fix: テスト分析で追加した問題が弱点分析に反映されない問題を修正

### DIFF
--- a/child-learning-app/src/components/TestScoreView.jsx
+++ b/child-learning-app/src/components/TestScoreView.jsx
@@ -10,6 +10,7 @@ import {
   updateProblem,
   deleteProblem,
 } from '../utils/problems'
+import { addLessonLogWithStats, EVALUATION_SCORES } from '../utils/lessonLogs'
 import { getSapixTexts } from '../utils/sapixTexts'
 import { addLessonLogWithStats, EVALUATION_SCORES } from '../utils/lessonLogs'
 import { addTaskToFirestore } from '../utils/firestore'
@@ -167,6 +168,21 @@ function TestScoreView({ user }) {
       imageUrl: problemForm.imageUrl || null,
     })
     if (result.success) {
+      // 弱点分析用に lessonLog も作成（単元が選択されている場合のみ）
+      if (problemForm.unitIds && problemForm.unitIds.length > 0) {
+        const evaluationKey = problemForm.isCorrect ? 'blue' : 'red'
+        await addLessonLogWithStats(user.uid, {
+          unitIds: problemForm.unitIds,
+          sourceType: 'test',
+          sourceId: selectedScore.firestoreId,
+          sourceName: `${selectedScore.testName} 問${problemForm.problemNumber}`,
+          date: selectedScore.testDate ? new Date(selectedScore.testDate) : new Date(),
+          performance: EVALUATION_SCORES[evaluationKey],
+          evaluationKey,
+          missType: problemForm.isCorrect ? null : (problemForm.missType || 'understanding'),
+          notes: `正答率: ${problemForm.correctRate || 0}%`,
+        })
+      }
       await reloadProblems()
       setProblemForm(getEmptyProblemForm())
       setShowProblemForm(false)


### PR DESCRIPTION
問題:
- 算数の問題は弱点分析に表示されるが、国語は表示されない
- テスト分析で問題を追加しても lessonLog が作成されていなかった
- 弱点分析（MasterUnitDashboard）は lessonLogs コレクションを参照

修正:
- handleSaveProblem で問題保存時に lessonLog も同時作成
- 単元が選択されている場合のみ lessonLog を作成
- 正解→blue(performance=90)、不正解→red(performance=30)
- sourceType='test'、sourceName にテスト名+問題番号を記録
- 全教科（算数・国語・理科・社会）で同じ動作になる

https://claude.ai/code/session_01TdzUBCnxia3ienbEbhZLfs