### PR TITLE
fix: AI総評生成時にテストの誤答データ（正答率）を取得して渡すように修正

### DIFF
--- a/child-learning-app/src/components/ScoreCard.jsx
+++ b/child-learning-app/src/components/ScoreCard.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { generateTestReview, getGeminiUsage } from '../utils/scoreOcr'
-import { updateTestScore } from '../utils/testScores'
+import { updateTestScore, getProblemsForTestScore } from '../utils/testScores'
 import { toast } from '../utils/toast'
 import './TestScoreView.css'
 
@@ -143,7 +143,9 @@ function AiReviewSection({ score, userId, onReload }) {
   const handleGenerate = async () => {
     setGenerating(true)
     try {
-      const reviewText = await generateTestReview(score, [])
+      const problems = await getProblemsForTestScore(userId, score)
+      const wrongAnswers = problems.filter(p => !p.isCorrect)
+      const reviewText = await generateTestReview(score, wrongAnswers)
       await updateTestScore(userId, score.id, { aiReview: reviewText })
       if (onReload) await onReload()
       setShowReview(true)


### PR DESCRIPTION
成績タブ移動時にgenerateTestReviewに空配列を渡していたため
正答率の評価ができなかった。getProblemsForTestScoreでFirestoreから
誤答データを取得してから総評を生成するように修正。

https://claude.ai/code/session_014UTmtNEHq45b3cHPxp8guH