### PR TITLE
feat: 家庭学習タスクに「第N回 単元名」を表示

### DIFF
--- a/child-learning-app/src/components/TodayAndWeekView.css
+++ b/child-learning-app/src/components/TodayAndWeekView.css
@@ -390,6 +390,24 @@
   white-space: nowrap;
 }
 
+/* 家庭学習タスクの「第N回 単元名」表示 */
+.hw-lesson-info {
+  display: inline-block;
+  margin-left: 0.5em;
+  padding: 0.05em 0.45em;
+  font-size: 0.78em;
+  font-weight: 500;
+  color: #475569;
+  background-color: #e2e8f0;
+  border-radius: 6px;
+  vertical-align: middle;
+}
+
+.priority-task.completed .hw-lesson-info,
+.week-hw-item.completed .hw-lesson-info {
+  opacity: 0.5;
+}
+
 /* モバイル対応 */
 @media (max-width: 768px) {
   .section-header h2 {

--- a/child-learning-app/src/components/TodayAndWeekView.jsx
+++ b/child-learning-app/src/components/TodayAndWeekView.jsx
@@ -118,7 +118,14 @@ function TodayAndWeekView({ tasks, homeworkDone, onToggleTask, onDeleteTask, onE
                       className="subject-badge"
                       style={{ color: subjectColor }}
                     >{hw.subject}</span>
-                    <span className="task-title">{hw.title}</span>
+                    <span className="task-title">
+                      {hw.title}
+                      {(hw.lessonLabel || hw.unitName) && (
+                        <span className="hw-lesson-info">
+                          {hw.lessonLabel}{hw.lessonLabel && hw.unitName ? ' ' : ''}{hw.unitName}
+                        </span>
+                      )}
+                    </span>
                     {pStyle && (
                       <span
                         className="task-priority-badge"
@@ -183,7 +190,14 @@ function TodayAndWeekView({ tasks, homeworkDone, onToggleTask, onDeleteTask, onE
                               className="week-hw-subject"
                               style={{ color: subjectColor }}
                             >{subjectEmojis[hw.subject]}</span>
-                            <span className="week-hw-title">{hw.title}</span>
+                            <span className="week-hw-title">
+                              {hw.title}
+                              {(hw.lessonLabel || hw.unitName) && (
+                                <span className="hw-lesson-info">
+                                  {hw.lessonLabel}{hw.lessonLabel && hw.unitName ? ' ' : ''}{hw.unitName}
+                                </span>
+                              )}
+                            </span>
                           </div>
                         )
                       })}

--- a/child-learning-app/src/utils/sapixHomework.js
+++ b/child-learning-app/src/utils/sapixHomework.js
@@ -4,6 +4,8 @@
 // 各教科の家庭学習優先順位（SAPIXカリキュラム共通）を
 // 授業翌日〜次回授業前日に自動配分する
 
+import { generateSapixSessions } from './sapixSchedule'
+
 // 授業スケジュール（曜日 → 教科リスト）
 // 0=日, 1=月, 2=火, 3=水, 4=木, 5=金, 6=土
 export const CLASS_SCHEDULE = {
@@ -188,6 +190,42 @@ function findLastClassDay(fromDate, classDayOfWeek) {
   return d
 }
 
+// studyCategory からテキスト種別（A/B/null）を判定
+// null = テキスト種別を問わない（理科/社会のように単一テキスト、または基礎トレ等）
+function textTypeForCategory(category) {
+  if (category === 'b-review' || category === 'b-practice' || category === 'b-brain') return 'B'
+  if (category === 'a-review' || category === 'a-exam') return 'A'
+  return null
+}
+
+// 授業日 + 教科 + テキスト種別から SAPIX セッション情報を取得
+// セッション一覧はモジュール初回参照時に1度だけ生成してキャッシュ
+let _sessionsCache = null
+function getSessionsCache() {
+  if (!_sessionsCache) _sessionsCache = generateSapixSessions()
+  return _sessionsCache
+}
+
+function findSession(classDate, subject, textType) {
+  const sessions = getSessionsCache()
+  return sessions.find(s => {
+    if (s.date !== classDate || s.subject !== subject) return false
+    // 算数・国語: A/B テキスト指定があれば textCode の prefix で絞り込み
+    if (textType === 'A') return /^4\dA-/.test(s.textCode)
+    if (textType === 'B') return /^4\dB-/.test(s.textCode)
+    // 理科 (430-XX) / 社会 (440-XX) は textType=null で1セッションのみ
+    return true
+  })
+}
+
+// テキストコードから「第N回」のラベルを生成（例: "41B-09" → "第9回"）
+function lessonLabelFromCode(code) {
+  if (!code) return ''
+  const m = code.match(/-(\d{2})$/)
+  if (!m) return ''
+  return `第${parseInt(m[1], 10)}回`
+}
+
 /**
  * 今週の家庭学習スケジュールを生成
  * @param {Date} today - 基準日（デフォルト: 今日）
@@ -224,6 +262,14 @@ export function generateWeeklyHomework(today = new Date()) {
       if (!templates) continue
 
       for (const template of templates) {
+        // SAPIX カリキュラムから「第N回」「単元名」「テキストコード」を解決
+        const textType = textTypeForCategory(template.studyCategory)
+        const session = findSession(classDayStr, subject, textType)
+        const textCode = session?.textCode || ''
+        const lessonLabel = lessonLabelFromCode(textCode)
+        const unitName = session?.name || ''
+        const unitIds = session?.unitIds || []
+
         for (const offset of template.dayOffsets) {
           const dueDate = addDays(classDate, offset)
           const dueDateStr = formatDate(dueDate)
@@ -238,6 +284,10 @@ export function generateWeeklyHomework(today = new Date()) {
             priority: template.priority,
             classDate: classDayStr,
             isHomework: true,
+            textCode,
+            lessonLabel,
+            unitName,
+            unitIds,
           })
         }
       }


### PR DESCRIPTION
家庭学習スケジュールが「Bテキスト 復習」のように汎用的で、
どの回のどの単元かが分からなかった。SAPIX 年間カリキュラム
(sapixSchedule.js) と連動させ、各タスクに textCode / lessonLabel / unitName / unitIds を付与し、UI でバッジ表示するようにした。

例: 「Bテキスト 復習」→「Bテキスト 復習 [第9回 規則性]」

https://claude.ai/code/session_01T1nmbyHiKRH6Vt9Ftp5uaj