### PR TITLE
fix: 単元マップが TDZ エラーで開けないバグを修正

### DIFF
--- a/child-learning-app/src/components/MasterUnitDashboard.jsx
+++ b/child-learning-app/src/components/MasterUnitDashboard.jsx
@@ -49,6 +49,30 @@ function MasterUnitDashboard({ sapixTexts = [], userId }) {
   // テキスト個別評価
   const [evaluatingTextId, setEvaluatingTextId] = useState(null)
 
+  const loadData = useCallback(async () => {
+    setLoading(true)
+    try {
+      if (!userId) return
+
+      const [units, logsResult] = await Promise.all([
+        Promise.resolve(getStaticMasterUnits()),
+        getLessonLogs(userId),
+      ])
+
+      setMasterUnits(units)
+
+      if (!logsResult.success) {
+        console.error('lessonLogs 読み取り失敗:', logsResult.error)
+      }
+      const logs = logsResult.success ? logsResult.data : []
+      setAllLogs(logs)  // stats は useEffect[allLogs] で自動再計算
+    } catch (err) {
+      console.error('データ取得エラー:', err)
+    } finally {
+      setLoading(false)
+    }
+  }, [userId])
+
   useEffect(() => {
     loadData()
   }, [loadData])
@@ -134,30 +158,6 @@ function MasterUnitDashboard({ sapixTexts = [], userId }) {
           }))
       })()
     : []
-
-  const loadData = useCallback(async () => {
-    setLoading(true)
-    try {
-      if (!userId) return
-
-      const [units, logsResult] = await Promise.all([
-        Promise.resolve(getStaticMasterUnits()),
-        getLessonLogs(userId),
-      ])
-
-      setMasterUnits(units)
-
-      if (!logsResult.success) {
-        console.error('lessonLogs 読み取り失敗:', logsResult.error)
-      }
-      const logs = logsResult.success ? logsResult.data : []
-      setAllLogs(logs)  // stats は useEffect[allLogs] で自動再計算
-    } catch (err) {
-      console.error('データ取得エラー:', err)
-    } finally {
-      setLoading(false)
-    }
-  }, [userId])
 
   // ドリルダウン：単元セルをタップ（同期処理。allLogsから即時フィルタ）
   const handleDrillDown = (unit) => {


### PR DESCRIPTION
直前のコミット e87d0dc で loadData を useCallback 化した際、
useEffect の deps 配列 [loadData] を追加したが loadData の宣言位置を そのまま後ろに残してしまっていた。useEffect の deps 配列はレンダー時に
評価されるため、const 宣言の TDZ により

  ReferenceError: Cannot access 'loadData' before initialization

がレンダー直後に投げられ、単元マップタブが開けなくなっていた。

loadData の useCallback 宣言を useEffect より前に移動して解消。
動作変更なし、lint・ビルド成功確認済み。