### PR TITLE
feat: 問題クリップの単元タグを全件表示（モバイル対応）

### DIFF
--- a/child-learning-app/src/components/ProblemClipList.css
+++ b/child-learning-app/src/components/ProblemClipList.css
@@ -115,7 +115,27 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  flex-shrink: 0;
+  flex-shrink: 1;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  min-width: 0;
+}
+.clip-item .clip-units {
+  justify-content: flex-end;
+}
+.clip-item .clip-units .unit-tag {
+  max-width: 140px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+@media (max-width: 480px) {
+  .clip-item {
+    flex-wrap: wrap;
+  }
+  .clip-item .clip-units .unit-tag {
+    max-width: 110px;
+  }
 }
 
 .clip-correctness {
@@ -205,6 +225,7 @@
   border-left: 4px solid transparent;
   cursor: pointer;
   transition: filter 0.15s;
+  flex-wrap: wrap;
 }
 .clip-g-item:hover {
   filter: brightness(0.96);
@@ -248,6 +269,15 @@
   padding: 1px 6px;
   border-radius: 4px;
 }
+/* 単元タグ群（グリッド表示）— 行内に複数並べ、足りなければ折り返す */
+.clip-g-units {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px;
+  flex: 1 1 auto;
+  min-width: 0;
+  justify-content: flex-end;
+}
 .clip-g-unit {
   font-size: 0.68rem;
   background: #f0fdf4;
@@ -258,6 +288,11 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+@media (max-width: 480px) {
+  .clip-g-unit {
+    max-width: 110px;
+  }
 }
 .clip-g-warn {
   font-size: 1rem;

--- a/child-learning-app/src/components/ProblemClipList.jsx
+++ b/child-learning-app/src/components/ProblemClipList.jsx
@@ -352,10 +352,13 @@ export default function ProblemClipList({
           <span className="clip-g-partial">部分点{problem.partialScore}</span>
         )}
         {problem.unitIds?.length > 0 && (
-          <span className="clip-g-unit" title={problem.unitIds.map(id => unitNameMap[id] || id).join('、')}>
-            {unitNameMap[problem.unitIds[0]] || problem.unitIds[0]}
-            {problem.unitIds.length > 1 && ` +${problem.unitIds.length - 1}`}
-          </span>
+          <div className="clip-g-units" title={problem.unitIds.map(id => unitNameMap[id] || id).join('、')}>
+            {problem.unitIds.map(id => (
+              <span key={id} className="clip-g-unit">
+                {unitNameMap[id] || id}
+              </span>
+            ))}
+          </div>
         )}
         {rate > 50 && <span className="clip-g-warn" title="正答率が高いのに間違えた問題">⚠️</span>}
         {problem.imageUrls?.length > 0 && <span className="clip-g-has-image" title="画像あり">📷</span>}
@@ -403,11 +406,10 @@ export default function ProblemClipList({
         </div>
         <div className="clip-item-right">
           {problem.unitIds?.length > 0 && (
-            <div className="clip-units">
-              {problem.unitIds.slice(0, 2).map(id => (
+            <div className="clip-units" title={problem.unitIds.map(id => unitNameMap[id] || id).join('、')}>
+              {problem.unitIds.map(id => (
                 <span key={id} className="unit-tag">{unitNameMap[id] || id}</span>
               ))}
-              {problem.unitIds.length > 2 && <span className="unit-tag">+{problem.unitIds.length - 2}</span>}
             </div>
           )}
           {problem.imageUrls?.length > 0 && <span className="clip-has-image" title="画像あり">📷{problem.imageUrls.length > 1 ? problem.imageUrls.length : ''}</span>}


### PR DESCRIPTION
問題クリップの単元表示が「1件 + N」または「2件 + N」と省略されていたため、
複数の単元タグを設定しても他のタグが隠れて確認しづらかった。

- グリッド表示 (clip-g-unit): clip-g-units コンテナで包んで全件表示 flex-wrap で行内に並べ、入り切らなければ折り返し。
- 通常表示 (clip-units): slice(0, 2) と +N 表示を撤去し全件表示。
- clip-item-right を flex-wrap 可能にし、モバイルでは行全体を折り返す ことで右側の単元タグが詰まらないようにする。
- 各タグに max-width を設定（PC 140px / モバイル 110px）し ellipsis で 長い単元名は省略表示。title 属性で全文をホバー時に確認可能。