### PR TITLE
feat: 問題クリップの単元タグを正答率/部分点の隣に配置

### DIFF
--- a/child-learning-app/src/components/ProblemClipList.css
+++ b/child-learning-app/src/components/ProblemClipList.css
@@ -115,14 +115,9 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  flex-shrink: 1;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-  min-width: 0;
+  flex-shrink: 0;
 }
-.clip-item .clip-units {
-  justify-content: flex-end;
-}
+/* 単元タグ（通常表示） — 正答率の隣に配置。長すぎる場合は ellipsis */
 .clip-item .clip-units .unit-tag {
   max-width: 140px;
   overflow: hidden;

--- a/child-learning-app/src/components/ProblemClipList.jsx
+++ b/child-learning-app/src/components/ProblemClipList.jsx
@@ -395,6 +395,13 @@ export default function ProblemClipList({
               {parseFloat(problem.correctRate).toFixed(1)}%
             </span>
           )}
+          {problem.unitIds?.length > 0 && (
+            <div className="clip-units" title={problem.unitIds.map(id => unitNameMap[id] || id).join('、')}>
+              {problem.unitIds.map(id => (
+                <span key={id} className="unit-tag">{unitNameMap[id] || id}</span>
+              ))}
+            </div>
+          )}
           {!problem.isCorrect && problem.correctRate != null && parseFloat(problem.correctRate) >= 50 && (
             <span className="clip-rate-warning" title="正答率50%以上で不正解 — 取るべき問題">
               🔺要注意
@@ -405,13 +412,7 @@ export default function ProblemClipList({
           )}
         </div>
         <div className="clip-item-right">
-          {problem.unitIds?.length > 0 && (
-            <div className="clip-units" title={problem.unitIds.map(id => unitNameMap[id] || id).join('、')}>
-              {problem.unitIds.map(id => (
-                <span key={id} className="unit-tag">{unitNameMap[id] || id}</span>
-              ))}
-            </div>
-          )}
+
           {problem.imageUrls?.length > 0 && <span className="clip-has-image" title="画像あり">📷{problem.imageUrls.length > 1 ? problem.imageUrls.length : ''}</span>}
           {!problem.isCorrect && (
             <span


### PR DESCRIPTION
これまで単元タグは行末（グリッド表示は warn/image の前、通常表示は
右側ペイン）に置かれており、正答率との関連が視覚的に分かりにくかった。

- グリッド表示: 「正答率 → 部分点 → 単元タグ」の順に配置 （部分点がない場合は正答率の直後）
- 通常表示: 単元タグを clip-item-right から clip-item-left に移し、 正答率のすぐ隣に表示。clip-item-right は画像と復習バッジのみに。
- clip-item-right の flex-shrink/wrap 調整を元に戻し、 単元タグの ellipsis ルール（PC 140px / モバイル 110px）は維持。