### PR TITLE
fix: 問題クリップ（グリッド表示）の項目並びを再調整

### DIFF
--- a/child-learning-app/src/components/ProblemClipList.css
+++ b/child-learning-app/src/components/ProblemClipList.css
@@ -269,9 +269,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 3px;
-  flex: 1 1 auto;
   min-width: 0;
-  justify-content: flex-end;
 }
 .clip-g-unit {
   font-size: 0.68rem;

--- a/child-learning-app/src/components/ProblemClipList.jsx
+++ b/child-learning-app/src/components/ProblemClipList.jsx
@@ -351,6 +351,7 @@ export default function ProblemClipList({
         {problem.partialScore != null && (
           <span className="clip-g-partial">部分点{problem.partialScore}</span>
         )}
+        {rate > 50 && <span className="clip-g-warn" title="正答率が高いのに間違えた問題">⚠️</span>}
         {problem.unitIds?.length > 0 && (
           <div className="clip-g-units" title={problem.unitIds.map(id => unitNameMap[id] || id).join('、')}>
             {problem.unitIds.map(id => (
@@ -360,7 +361,6 @@ export default function ProblemClipList({
             ))}
           </div>
         )}
-        {rate > 50 && <span className="clip-g-warn" title="正答率が高いのに間違えた問題">⚠️</span>}
         {problem.imageUrls?.length > 0 && <span className="clip-g-has-image" title="画像あり">📷</span>}
       </div>
     )


### PR DESCRIPTION
スクリーンショットの実際の表示を見直し、左から
  正答率 → 部分点 → ⚠️注意マーク → 単元タグ → 📷画像
の順に並ぶよう JSX を再配置。

CSS: clip-g-units の flex:1 1 auto を撤去し、コンテナが右端まで
伸びないように修正。これで単元タグが ⚠️ の直後に詰まって表示される。