### PR TITLE
feat: 主要モーダルに「✓ 完了」ボタンを追加

### DIFF
--- a/child-learning-app/src/components/MasterUnitDashboard.css
+++ b/child-learning-app/src/components/MasterUnitDashboard.css
@@ -749,6 +749,25 @@
   text-align: center;
 }
 
+.mud-drill-footer {
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid var(--color-gray-200);
+  display: flex;
+  justify-content: flex-end;
+}
+.mud-drill-done-btn {
+  padding: 8px 22px;
+  background: var(--color-primary);
+  color: white;
+  border: 1px solid var(--color-primary);
+  border-radius: 6px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+.mud-drill-done-btn:hover { filter: brightness(0.95); }
+
 .mud-drill-reset-btn {
   padding: 8px 20px;
   background: none;

--- a/child-learning-app/src/components/MasterUnitDashboard.jsx
+++ b/child-learning-app/src/components/MasterUnitDashboard.jsx
@@ -651,6 +651,12 @@ function MasterUnitDashboard({ sapixTexts = [], userId }) {
                 {resetting ? 'リセット中...' : 'この単元のデータを初期化'}
               </button>
             </div>
+
+            <div className="mud-drill-footer">
+              <button className="mud-drill-done-btn" onClick={() => setDrillUnit(null)}>
+                ✓ 完了
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/child-learning-app/src/components/ProblemClipList.css
+++ b/child-learning-app/src/components/ProblemClipList.css
@@ -706,6 +706,18 @@
 }
 .clip-delete-btn:hover { background: var(--color-danger-bg); }
 
+.clip-done-btn {
+  padding: 6px 18px;
+  border: 1px solid var(--color-primary);
+  border-radius: 6px;
+  background: var(--color-primary);
+  color: white;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+.clip-done-btn:hover { filter: brightness(0.95); }
+
 /* ── PDF切り出し科目タブ（問題追加フロー用）───────────── */
 
 .clip-cropper-subject-tabs {

--- a/child-learning-app/src/components/ProblemClipList.jsx
+++ b/child-learning-app/src/components/ProblemClipList.jsx
@@ -637,6 +637,12 @@ export default function ProblemClipList({
             >
               削除
             </button>
+            <button
+              className="clip-done-btn"
+              onClick={() => { setSelectedProblem(null); setTaskDueDate(null) }}
+            >
+              ✓ 完了
+            </button>
           </div>
         </div>
       </div>,

--- a/child-learning-app/src/components/TestRangeProblems.css
+++ b/child-learning-app/src/components/TestRangeProblems.css
@@ -57,6 +57,28 @@
   background: var(--color-gray-100, #f3f4f6);
 }
 
+.range-problems-footer {
+  display: flex;
+  justify-content: flex-end;
+  padding: 12px 20px;
+  border-top: 1px solid var(--color-gray-100, #f3f4f6);
+  background: white;
+}
+
+.range-problems-done-btn {
+  padding: 8px 22px;
+  background: var(--color-primary);
+  color: white;
+  border: 1px solid var(--color-primary);
+  border-radius: 6px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+.range-problems-done-btn:hover {
+  filter: brightness(0.95);
+}
+
 .range-problems-body {
   flex: 1;
   overflow-y: auto;

--- a/child-learning-app/src/components/TestRangeProblems.jsx
+++ b/child-learning-app/src/components/TestRangeProblems.jsx
@@ -190,6 +190,12 @@ function TestRangeProblems({ userId, sapixRange, testName, sapixTexts, onClose, 
             </>
           )}
         </div>
+
+        <div className="range-problems-footer">
+          <button className="range-problems-done-btn" onClick={onClose}>
+            ✓ 完了
+          </button>
+        </div>
       </div>
 
       {zoomedImage && (


### PR DESCRIPTION
## Summary

X (×) ボタンまたは overlay クリックでしか閉じられないモーダルに、明示的な「✓ 完了」ボタンを追加。編集後に作業終了を明確に示せるようにする。

## 対応した 3 モーダル

| ファイル | モーダル | 編集内容 |
|---|---|---|
| `ProblemClipList.jsx` | 問題クリップ詳細 | 単元 / 部分点 / ミス種別 / 解き直しステータス |
| `MasterUnitDashboard.jsx` | 単元ドリルダウン | 評価記録・テキスト評価・データ初期化 |
| `TestRangeProblems.jsx` | 範囲別間違い問題 | 「できた」状態変更 |

すべて青い「✓ 完了」ボタンをフッター右端に配置。X ボタン・overlay クリックでの close も従来通り使えます。

## 追加不要と判断したモーダル

調査の結果、以下は既にフッターに閉じるボタン or キャンセル/保存パターンが整っており追加不要:

- `TaskDetailModal.jsx` (「閉じる」フッターボタン済み)
- `TextDetailModal.jsx` (「閉じる」フッター済み)
- `SettingsModal.jsx` (「閉じる」フッター済み)
- `QuickMistakeInput.jsx` (状態別ボタン揃い)
- `MasterUnitEditor.jsx` (キャンセル/保存)
- `GradesView.jsx` 編集フォーム (キャンセル/保存)
- `PdfCropper.jsx` (完了/閉じる済み)
- `DriveFilePicker.jsx` (選択即確定パターン)
- PDF フルスクリーンビュー各種 (閲覧専用)

## Test plan

- [ ] テストタブ → 問題クリップを開いて編集 → 「✓ 完了」で閉じる
- [ ] 単元マップタブ → 単元セルをクリック → ドリルダウンで「✓ 完了」で閉じる
- [ ] テストタブ → 範囲別間違い問題モーダル → 「✓ 完了」で閉じる
- [ ] いずれも X ボタン / overlay クリックでの close が引き続き動く

`npm run lint`: 0 warning、`npm run build`: 成功確認済み。


---
_Generated by [Claude Code](https://claude.ai/code/session_0193wWypdTVsezafB6Z53xDP)_