### PR TITLE
feat: テスト復習スケジュールを自動生成（翌日 / 1週間後 / 1ヶ月後）

### DIFF
--- a/child-learning-app/src/App.jsx
+++ b/child-learning-app/src/App.jsx
@@ -296,11 +296,13 @@ function App() {
             {/* 1. 今日と今週のタスク（最優先） */}
             <TodayAndWeekView
               tasks={tasks}
+              testScores={testScores}
               homeworkDone={homeworkDone}
               onToggleTask={toggleTask}
               onDeleteTask={deleteTask}
               onEditTask={handleEditTask}
               onToggleHomework={toggleHomework}
+              onTestClick={handleTestClick}
               userId={user.uid}
             />
 

--- a/child-learning-app/src/components/TodayAndWeekView.css
+++ b/child-learning-app/src/components/TodayAndWeekView.css
@@ -2,6 +2,81 @@
   margin-bottom: 30px;
 }
 
+/* ─── テスト復習のバナー通知 ───────────────────────── */
+.review-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 16px;
+  margin-bottom: 16px;
+  background: linear-gradient(90deg, #fff7ed, #ffedd5);
+  border: 1px solid #fdba74;
+  border-radius: 12px;
+  color: #9a3412;
+  font-size: 0.95rem;
+  box-shadow: 0 2px 6px rgba(251, 146, 60, 0.18);
+}
+.review-banner-icon {
+  font-size: 1.2rem;
+}
+.review-banner-text strong {
+  color: #c2410c;
+  font-weight: 700;
+}
+
+/* ─── 復習タスク（今日リスト用）───────────────────── */
+.priority-task.review-task {
+  border-color: #fb923c;
+  background-color: #fff7ed;
+  box-shadow: 0 2px 8px rgba(251, 146, 60, 0.25);
+}
+.priority-task.review-task.completed {
+  opacity: 0.6;
+}
+.review-badge {
+  font-size: 0.78rem;
+  padding: 2px 8px;
+  background: #c2410c;
+  color: white;
+  border-radius: 10px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+.review-task-title {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  font-size: 0.95rem;
+  color: #1f2937;
+  padding: 0;
+  font-weight: 600;
+}
+.review-task-title:hover {
+  text-decoration: underline;
+}
+.review-interval {
+  font-size: 0.75rem;
+  padding: 1px 8px;
+  background: #fed7aa;
+  color: #9a3412;
+  border-radius: 8px;
+  font-weight: 500;
+}
+
+/* ─── 復習タスク（週間表示用）───────────────────── */
+.week-hw-item.week-review-item {
+  background: #fff7ed;
+  border-left: 3px solid #fb923c;
+}
+.week-review-badge {
+  font-size: 0.9rem;
+}
+
 .priority-section {
   background: var(--color-white);
   border-radius: 16px;

--- a/child-learning-app/src/components/TodayAndWeekView.jsx
+++ b/child-learning-app/src/components/TodayAndWeekView.jsx
@@ -3,6 +3,7 @@ import './TodayAndWeekView.css'
 import { subjectEmojis, subjectColors, weekDayNames } from '../utils/constants'
 import { formatDate, parseLocalDate } from '../utils/dateUtils'
 import { getHomeworkForDate, getHomeworkByDate } from '../utils/sapixHomework'
+import { getTestReviewsForDate, getTestReviewsByDate } from '../utils/testReviews'
 import TaskDetailModal from './TaskDetailModal'
 
 // 優先度のラベルと色
@@ -12,7 +13,7 @@ const priorityStyles = {
   C: { label: 'C', color: '#3b82f6' },
 }
 
-function TodayAndWeekView({ tasks, homeworkDone, onToggleTask, onDeleteTask, onEditTask, onToggleHomework, userId }) {
+function TodayAndWeekView({ tasks, testScores = [], homeworkDone, onToggleTask, onDeleteTask, onEditTask, onToggleHomework, onTestClick, userId }) {
   const [expandedSection, setExpandedSection] = useState('today') // 'today', 'homework', 'week'
   const [detailTask, setDetailTask] = useState(null)
   const [todayStr, setTodayStr] = useState(() => formatDate(new Date()))
@@ -35,13 +36,27 @@ function TodayAndWeekView({ tasks, homeworkDone, onToggleTask, onDeleteTask, onE
 
   const weekHomework = useMemo(() => getHomeworkByDate(parseLocalDate(todayStr), 7), [todayStr])
 
-  // 家庭学習の完了チェック
+  // テスト復習タスク（翌日 / 1週間後 / 1ヶ月後）
+  const todayReviews = useMemo(
+    () => getTestReviewsForDate(testScores, parseLocalDate(todayStr)),
+    [testScores, todayStr]
+  )
+  const weekReviewsByDate = useMemo(
+    () => getTestReviewsByDate(testScores, parseLocalDate(todayStr), 7),
+    [testScores, todayStr]
+  )
+
+  // 家庭学習の完了チェック（復習タスクも homeworkDone に同居している）
   const isHomeworkDone = (hwId) => {
     return homeworkDone && homeworkDone[hwId] === true
   }
 
-  const todayHomeworkCount = todayHomework.length
-  const todayHomeworkDoneCount = todayHomework.filter(hw => isHomeworkDone(hw.id)).length
+  const todayHomeworkCount = todayHomework.length + todayReviews.length
+  const todayHomeworkDoneCount =
+    todayHomework.filter(hw => isHomeworkDone(hw.id)).length +
+    todayReviews.filter(r => isHomeworkDone(r.id)).length
+
+  const undoneReviewCount = todayReviews.filter(r => !isHomeworkDone(r.id)).length
 
   const toggleSection = (section) => {
     setExpandedSection(expandedSection === section ? null : section)
@@ -57,6 +72,16 @@ function TodayAndWeekView({ tasks, homeworkDone, onToggleTask, onDeleteTask, onE
 
   return (
     <div className="today-week-view">
+      {/* テスト復習のバナー通知 */}
+      {undoneReviewCount > 0 && (
+        <div className="review-banner" role="status">
+          <span className="review-banner-icon">🔁</span>
+          <span className="review-banner-text">
+            今日は <strong>テスト復習が{undoneReviewCount}件</strong> あります
+          </span>
+        </div>
+      )}
+
       {/* 今日の家庭学習 */}
       <div className="priority-section homework-section">
         <div
@@ -74,7 +99,33 @@ function TodayAndWeekView({ tasks, homeworkDone, onToggleTask, onDeleteTask, onE
 
         {expandedSection === 'today' && (
           <div className="task-grid">
-            {todayHomework.length === 0 ? (
+            {/* テスト復習タスク（家庭学習の上に配置） */}
+            {todayReviews.map(r => {
+              const done = isHomeworkDone(r.id)
+              return (
+                <div
+                  key={r.id}
+                  className={`priority-task review-task ${done ? 'completed' : ''}`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={done}
+                    onChange={() => onToggleHomework && onToggleHomework(r.id)}
+                    className="task-checkbox"
+                  />
+                  <span className="review-badge">🔁 復習</span>
+                  <button
+                    type="button"
+                    className="review-task-title"
+                    onClick={() => onTestClick && onTestClick(r.testId)}
+                  >
+                    {r.testName}
+                    <span className="review-interval">{r.intervalLabel}</span>
+                  </button>
+                </div>
+              )
+            })}
+            {todayHomework.length === 0 && todayReviews.length === 0 ? (
               <div className="no-tasks-message">今日の家庭学習はありません</div>
             ) : (
               todayHomework.map(hw => {
@@ -145,7 +196,11 @@ function TodayAndWeekView({ tasks, homeworkDone, onToggleTask, onDeleteTask, onE
               const d = parseLocalDate(dateStr)
               const dayName = weekDayNames[d.getDay()]
               const isToday = dateStr === formatDate(new Date())
-              const doneCount = hwTasks.filter(hw => isHomeworkDone(hw.id)).length
+              const reviewsForDay = weekReviewsByDate[dateStr] || []
+              const totalCount = hwTasks.length + reviewsForDay.length
+              const doneCount =
+                hwTasks.filter(hw => isHomeworkDone(hw.id)).length +
+                reviewsForDay.filter(r => isHomeworkDone(r.id)).length
 
               return (
                 <div key={dateStr} className={`week-day-block ${isToday ? 'is-today' : ''}`}>
@@ -154,14 +209,31 @@ function TodayAndWeekView({ tasks, homeworkDone, onToggleTask, onDeleteTask, onE
                       {d.getMonth() + 1}/{d.getDate()}({dayName})
                       {isToday && <span className="today-badge">TODAY</span>}
                     </span>
-                    {hwTasks.length > 0 && (
-                      <span className="week-day-count">{doneCount}/{hwTasks.length}</span>
+                    {totalCount > 0 && (
+                      <span className="week-day-count">{doneCount}/{totalCount}</span>
                     )}
                   </div>
-                  {hwTasks.length === 0 ? (
+                  {totalCount === 0 ? (
                     <div className="week-day-empty">-</div>
                   ) : (
                     <div className="week-day-tasks">
+                      {reviewsForDay.map(r => {
+                        const done = isHomeworkDone(r.id)
+                        return (
+                          <div
+                            key={r.id}
+                            className={`week-hw-item week-review-item ${done ? 'completed' : ''}`}
+                            onClick={() => onToggleHomework && onToggleHomework(r.id)}
+                          >
+                            <span className="week-hw-check">{done ? '✓' : '○'}</span>
+                            <span className="week-review-badge">🔁</span>
+                            <span className="week-hw-title">
+                              {r.testName}
+                              <span className="hw-lesson-info">{r.intervalLabel}</span>
+                            </span>
+                          </div>
+                        )
+                      })}
                       {hwTasks.map(hw => {
                         const subjectColor = subjectColors[hw.subject] || '#64748b'
                         const done = isHomeworkDone(hw.id)

--- a/child-learning-app/src/utils/testReviews.js
+++ b/child-learning-app/src/utils/testReviews.js
@@ -1,0 +1,82 @@
+// テスト復習スケジュール自動生成
+//
+// エビングハウス忘却曲線に基づく分散学習スケジュール:
+//   翌日 / 1週間後 / 1ヶ月後
+//
+// 各テスト (testScores) ごとに上記 3 タイミングの復習タスクを生成。
+// データは Firestore に保存せず、testScores から都度生成する。
+// 完了状態は既存の homeworkDone マップに review-* キーで保持する。
+
+import { formatDate, parseLocalDate, addDays } from './dateUtils'
+
+export const REVIEW_INTERVALS = [
+  { key: 'next-day',  label: '翌日',     daysAfter: 1,  priority: 'A' },
+  { key: 'one-week',  label: '1週間後',  daysAfter: 7,  priority: 'A' },
+  { key: 'one-month', label: '1ヶ月後',  daysAfter: 30, priority: 'B' },
+]
+
+/**
+ * 単一テストから全復習タスクを生成
+ */
+function reviewsForTest(test) {
+  if (!test?.testDate || !test?.id) return []
+  const testDate = parseLocalDate(test.testDate)
+  if (!testDate || isNaN(testDate.getTime())) return []
+  return REVIEW_INTERVALS.map(interval => {
+    const dueDate = addDays(testDate, interval.daysAfter)
+    return {
+      id: `review-${test.id}-${interval.key}`,
+      testId: test.id,
+      testName: test.testName || '(無題のテスト)',
+      testDate: test.testDate,
+      intervalKey: interval.key,
+      intervalLabel: interval.label,
+      dueDate: formatDate(dueDate),
+      priority: interval.priority,
+      isReview: true,
+    }
+  })
+}
+
+/**
+ * すべての復習タスクを生成
+ * @param {Array} tests testScores 配列
+ * @returns {Array} 復習タスク配列
+ */
+export function generateTestReviews(tests = []) {
+  const all = []
+  for (const t of tests) all.push(...reviewsForTest(t))
+  return all
+}
+
+/**
+ * 指定日に該当する復習タスクを取得（優先度順）
+ */
+export function getTestReviewsForDate(tests, date = new Date()) {
+  const dateStr = formatDate(date)
+  return generateTestReviews(tests)
+    .filter(r => r.dueDate === dateStr)
+    .sort((a, b) => {
+      if (a.priority !== b.priority) return a.priority.localeCompare(b.priority)
+      return (a.testDate || '').localeCompare(b.testDate || '')
+    })
+}
+
+/**
+ * 今日 〜 today+days 日間の復習タスクを日付別に
+ */
+export function getTestReviewsByDate(tests, today = new Date(), days = 7) {
+  const all = generateTestReviews(tests)
+  const result = {}
+  for (let i = 0; i < days; i++) {
+    const d = addDays(today, i)
+    const dateStr = formatDate(d)
+    result[dateStr] = all
+      .filter(r => r.dueDate === dateStr)
+      .sort((a, b) => {
+        if (a.priority !== b.priority) return a.priority.localeCompare(b.priority)
+        return (a.testDate || '').localeCompare(b.testDate || '')
+      })
+  }
+  return result
+}


### PR DESCRIPTION
## Summary

エビングハウス忘却曲線に基づく分散学習スケジュールを実装。各テスト (testScores) ごとに **翌日 / 1週間後 / 1ヶ月後** の 3 段階の復習タスクが自動生成され、今日の家庭学習に混在表示される。

## 学習効果の設計判断

| 経過 | 復習なし保持率 | 効果 |
|---|---|---|
| 翌日 | 33% | 初期固定化 |
| 1週間後 | 25% | 中期記憶化 |
| 1ヶ月後 | 21% | 長期記憶化 |

3 段階で必要十分なエビングハウス間隔をカバー。問題クリップに既にある「正答率高×不正解＝🔺要注意」マークと組み合わせて、限られた時間で最優先で取るべき問題が一目で分かる動線。

## 変更内容

### 新規: `src/utils/testReviews.js`
- `REVIEW_INTERVALS` 定数 (next-day / one-week / one-month)
- `generateTestReviews` / `getTestReviewsForDate` / `getTestReviewsByDate`
- データは Firestore に保存せず testScores から都度生成（テスト削除で自動消滅、孤児データなし）

### `TodayAndWeekView.jsx`
- `testScores` と `onTestClick` props を受け取り、復習タスクを生成
- 今日リストの先頭に「🔁 復習」タスクを表示（オレンジ系の専用色）
- タップでテスト詳細画面へ遷移
- 週間カレンダーにも各日の復習を表示
- 完了状態は既存の `homeworkDone` マップに `review-*` キーで同居
  （別 Firestore 書き込み不要、整合性◯）

### 起動時バナー通知
今日の未完復習があれば画面上部にオレンジバナーで `🔁 今日はテスト復習がN件あります` と通知。

### `App.jsx`
TodayAndWeekView に testScores と onTestClick を追加で渡す。

### CSS
review-banner / review-task / review-badge / review-interval / week-review-item の色テーマ追加（既存の家庭学習＝青、復習＝橙で区別）

## Test plan

- [ ] 既存のテストを記録 → 翌日、1週間後、1ヶ月後に復習タスクが「今日の家庭学習」に出ること
- [ ] 復習チェックボックスで完了状態が保存・復元されること
- [ ] 復習をタップで該当テスト詳細に遷移すること
- [ ] 起動時バナーが未完復習件数を正しく表示
- [ ] 週間カレンダーに各日の復習件数が反映 (`doneCount/totalCount`)
- [ ] テスト削除すると関連復習が消滅すること（孤児なし）

`npm run lint`: 0 warning、`npm run build`: 成功確認済み。

## 今後の拡張候補（別 PR で）

1. 復習完了時に lessonLogs へ評価記録を促す（単元マップ自動更新）
2. 連続復習日数の可視化（習慣化促進）
3. アダプティブ間隔（Anki方式: 正解で延長、不正解で短縮）
4. PWA + Push 通知
5. 復習タップ時に「これだけやればOK」リスト（不正解+要注意+部分点）を自動表示


---
_Generated by [Claude Code](https://claude.ai/code/session_0193wWypdTVsezafB6Z53xDP)_