### PR TITLE
feat: 夏期講習の日程（全14回）と 4α 時間割を追加

### DIFF
--- a/child-learning-app/src/components/WeeklyCalendar.css
+++ b/child-learning-app/src/components/WeeklyCalendar.css
@@ -537,6 +537,18 @@
   white-space: nowrap;
 }
 
+/* 季節講習マーカー（夏期講習など・教科未定）— 緑系で強調 */
+.calendar-lesson.season-marker {
+  background: #ecfdf5;
+  border: 1px solid #6ee7b7;
+  color: #047857;
+  font-weight: 600;
+}
+.lesson-dot.season-dot-marker {
+  background: #ecfdf5;
+  border: 1px solid #6ee7b7;
+}
+
 .calendar-lesson.clickable-row {
   cursor: pointer;
   transition: all 0.15s;

--- a/child-learning-app/src/components/WeeklyCalendar.jsx
+++ b/child-learning-app/src/components/WeeklyCalendar.jsx
@@ -152,6 +152,20 @@ function WeeklyCalendar({ tasks, sapixTexts = [], testScores = [], onToggleTask,
   // ── セッション行の描画（週間ビュー用）──────────────────────
   const renderSessionItem = (item, index) => {
     const linked = item.linkedText
+    // 季節講習マーカー（教科・テキスト未割当）は「未登録」扱いにせず名称のみ表示
+    const isSeasonMarker = !item.textCode && !item.subject
+    if (isSeasonMarker) {
+      return (
+        <div
+          key={`session-${index}`}
+          className="calendar-lesson season-marker"
+          title={item.name}
+        >
+          <span className="lesson-icon">🏫</span>
+          <span className="lesson-name">{item.name}</span>
+        </div>
+      )
+    }
     return (
       <div
         key={`session-${item.textCode || index}`}
@@ -176,6 +190,14 @@ function WeeklyCalendar({ tasks, sapixTexts = [], testScores = [], onToggleTask,
   // ── セッションドットの描画（月間ビュー用）─────────────────
   const renderSessionDot = (item, index) => {
     const linked = item.linkedText
+    const isSeasonMarker = !item.textCode && !item.subject
+    if (isSeasonMarker) {
+      return (
+        <div key={`dot-${index}`} className="lesson-dot season-dot-marker" title={item.name}>
+          🏫
+        </div>
+      )
+    }
     return (
       <div
         key={`dot-${item.textCode || index}`}

--- a/child-learning-app/src/utils/sapixHomework.js
+++ b/child-learning-app/src/utils/sapixHomework.js
@@ -276,6 +276,8 @@ function generateSeasonHomework(sessions, today, allTasks) {
   const horizonStr = formatDate(addDays(today, 6))
   for (const s of sessions) {
     if (!SEASON_DNUMBERS.has(s.dNumber)) continue
+    // 教科・テキスト未割当のマーカー（夏期講習など）は家庭学習タスクを生成しない
+    if (!s.subject || !s.textCode) continue
     const classDate = parseLocalDate(s.date)
     const dueDate = addDays(classDate, 1)
     const dueDateStr = formatDate(dueDate)

--- a/child-learning-app/src/utils/sapixSchedule.js
+++ b/child-learning-app/src/utils/sapixSchedule.js
@@ -478,6 +478,27 @@ const SAPIX_SPRING_CALENDAR_4_2026_ALPHA = {
   '2026-04-02': ['H41-05', 'H42-04', 'H43-03'],  // 算数5, 国語4, 理科3
 }
 
+// 夏期講習カレンダー（4αクラス・206教室）
+// 各日 3 コマ (9:00-10:00, 10:00-11:00, 11:00-12:00)。
+// 仙川校 2026年度4年生 夏期講習時間割 PDF の 4α 行を反映。
+// 数字は各教科の回数（算数1 = N41-01）。算数14/国語12/理科8/社会8 = 全42コマ。
+const SAPIX_SUMMER_CALENDAR_4_2026_ALPHA = {
+  '2026-07-30': ['N41-01', 'N42-01', 'N44-01'],  // 算数1, 国語1, 社会1
+  '2026-07-31': ['N41-02', 'N42-02', 'N43-01'],  // 算数2, 国語2, 理科1
+  '2026-08-02': ['N41-03', 'N42-03', 'N44-02'],  // 算数3, 国語3, 社会2
+  '2026-08-03': ['N41-04', 'N43-02', 'N44-03'],  // 算数4, 理科2, 社会3
+  '2026-08-06': ['N41-05', 'N42-04', 'N43-03'],  // 算数5, 国語4, 理科3
+  '2026-08-07': ['N41-06', 'N42-05', 'N44-04'],  // 算数6, 国語5, 社会4
+  '2026-08-08': ['N41-07', 'N42-06', 'N43-04'],  // 算数7, 国語6, 理科4
+  '2026-08-15': ['N41-08', 'N42-07', 'N44-05'],  // 算数8, 国語7, 社会5
+  '2026-08-16': ['N41-09', 'N42-08', 'N43-05'],  // 算数9, 国語8, 理科5
+  '2026-08-18': ['N41-10', 'N42-09', 'N44-06'],  // 算数10, 国語9, 社会6
+  '2026-08-19': ['N41-11', 'N43-06', 'N44-07'],  // 算数11, 理科6, 社会7
+  '2026-08-21': ['N41-12', 'N42-10', 'N43-07'],  // 算数12, 国語10, 理科7
+  '2026-08-22': ['N41-13', 'N42-11', 'N44-08'],  // 算数13, 国語11, 社会8
+  '2026-08-23': ['N41-14', 'N42-12', 'N43-08'],  // 算数14, 国語12, 理科8
+}
+
 // 冬期講習日程（全6日, 9:00-12:00 60分×3コマ, 算数6/国語6/理科3/社会3）
 export const SAPIX_WINTER_4_2026 = [
   { date: '2026-12-26', day: '土' },
@@ -542,7 +563,18 @@ export function gradeFromCode(code) {
  * @returns {string|null} - 例: "2026-02-18" or null
  */
 export function getStudyDateFromCode(code) {
-  // テキストコードから連番を抽出
+  // 季節講習コード（H:春期 / N:夏期 / F:冬期）はカレンダーから逆引き
+  if (/^[HNF]\d{2}-\d{2}/.test(code)) {
+    const seasonCal =
+      code.startsWith('H') ? SAPIX_SPRING_CALENDAR_4_2026_ALPHA :
+      code.startsWith('N') ? SAPIX_SUMMER_CALENDAR_4_2026_ALPHA :
+      SAPIX_WINTER_CALENDAR_4_2026_ALPHA
+    for (const [date, codes] of Object.entries(seasonCal)) {
+      if (codes.includes(code)) return date
+    }
+    return null
+  }
+  // 通常授業コードから連番を抽出
   const numMatch = code.match(/^(?:41[AB]|42[AB]|43\d|44\d)-(\d{2})$/)
   if (!numMatch) return null
   const num = parseInt(numMatch[1])
@@ -619,10 +651,14 @@ export function generateSapixSessions() {
     }
   }
 
-  // 夏期講習マーカー（教科・テキスト割当は未定のため日付のみ登録）
-  // textCode/subject を持たないため家庭学習タスク生成の対象外（下記参照）。
-  for (const { date } of SAPIX_SUMMER_4_2026) {
-    sessions.push({ date, dNumber: '夏期', subject: null, textCode: '', name: '夏期講習', unitIds: [] })
+  // 夏期講習セッション（4αクラス）
+  for (const [date, codes] of Object.entries(SAPIX_SUMMER_CALENDAR_4_2026_ALPHA)) {
+    for (const code of codes) {
+      const info = SAPIX_SCHEDULE[code]
+      if (info) {
+        sessions.push({ date, dNumber: '夏期', subject: info.subject, textCode: code, name: info.name, unitIds: info.unitIds })
+      }
+    }
   }
 
   return sessions.sort((a, b) => a.date.localeCompare(b.date))

--- a/child-learning-app/src/utils/sapixSchedule.js
+++ b/child-learning-app/src/utils/sapixSchedule.js
@@ -447,6 +447,27 @@ export const SAPIX_SPRING_4_2026 = [
   { date: '2026-04-02', day: '木' },
 ]
 
+// 夏期講習日程（全14回）
+// 教科割当（どの日にどの教科・テキストか）は未定のため、日付のみ登録。
+// カレンダー上に「夏期講習」マーカーとして表示する。
+export const SAPIX_SUMMER_4_2026 = [
+  { date: '2026-07-30', day: '木' },  // 1（新コース開始）
+  { date: '2026-07-31', day: '金' },  // 2
+  { date: '2026-08-02', day: '日' },  // 3
+  { date: '2026-08-03', day: '月' },  // 4
+  { date: '2026-08-06', day: '木' },  // 5
+  { date: '2026-08-07', day: '金' },  // 6
+  { date: '2026-08-08', day: '土' },  // 7
+  { date: '2026-08-15', day: '土' },  // 8
+  { date: '2026-08-16', day: '日' },  // 9
+  { date: '2026-08-18', day: '火' },  // 10
+  { date: '2026-08-19', day: '水' },  // 11
+  { date: '2026-08-21', day: '金' },  // 12
+  { date: '2026-08-22', day: '土' },  // 13
+  { date: '2026-08-23', day: '日' },  // 14
+  // 8/28(金) 夏期講習マンスリー確認テスト（講習日ではないため含めない）
+]
+
 // 春期講習カレンダー（αクラス）
 // 各日の授業: [9:00-10:00, 10:00-11:00, 11:00-12:00]
 const SAPIX_SPRING_CALENDAR_4_2026_ALPHA = {
@@ -596,6 +617,12 @@ export function generateSapixSessions() {
         sessions.push({ date, dNumber: '冬期', subject: info.subject, textCode: code, name: info.name, unitIds: info.unitIds })
       }
     }
+  }
+
+  // 夏期講習マーカー（教科・テキスト割当は未定のため日付のみ登録）
+  // textCode/subject を持たないため家庭学習タスク生成の対象外（下記参照）。
+  for (const { date } of SAPIX_SUMMER_4_2026) {
+    sessions.push({ date, dNumber: '夏期', subject: null, textCode: '', name: '夏期講習', unitIds: [] })
   }
 
   return sessions.sort((a, b) => a.date.localeCompare(b.date))


### PR DESCRIPTION
## Summary

仙川校 2026年度4年生 夏期講習の日程（全14回）と、夏期講習時間割 PDF の 4α（206教室）教科割当を `sapixSchedule.js` に登録。

（後期スケジュール本体は PR #386 でマージ済み。本 PR はその後に追加した夏期講習分。）

## 追加内容

### 1. 夏期講習日程（全14回）
- 7/30(木・新コース開始), 7/31(金)
- 8/2(日), 8/3(月), 8/6(木), 8/7(金), 8/8(土)
- 8/15(土), 8/16(日), 8/18(火), 8/19(水), 8/21(金), 8/22(土), 8/23(日)
  （8/28 のマンスリー確認テストは講習日ではないため含めない）

### 2. 夏期講習4α 教科割当（時間割）
時間割 PDF の 4α（206教室）行を反映。各日3コマ:

| 日付 | 1限 | 2限 | 3限 |
|---|---|---|---|
| 7/30 | 算数1 | 国語1 | 社会1 |
| 7/31 | 算数2 | 国語2 | 理科1 |
| 8/2 | 算数3 | 国語3 | 社会2 |
| 8/3 | 算数4 | 理科2 | 社会3 |
| 8/6 | 算数5 | 国語4 | 理科3 |
| 8/7 | 算数6 | 国語5 | 社会4 |
| 8/8 | 算数7 | 国語6 | 理科4 |
| 8/15 | 算数8 | 国語7 | 社会5 |
| 8/16 | 算数9 | 国語8 | 理科5 |
| 8/18 | 算数10 | 国語9 | 社会6 |
| 8/19 | 算数11 | 理科6 | 社会7 |
| 8/21 | 算数12 | 国語10 | 理科7 |
| 8/22 | 算数13 | 国語11 | 社会8 |
| 8/23 | 算数14 | 国語12 | 理科8 |

教科別: 算数 N41-01〜14 / 国語 N42-01〜12 / 理科 N43-01〜08 / 社会 N44-01〜08（全42コマ、各連番の漏れなしを検証済み）

## 実装

- `SAPIX_SUMMER_4_2026`（日付＋曜日リスト）を新規 export
- `SAPIX_SUMMER_CALENDAR_4_2026_ALPHA`（4α 各日3コマの教科割当）を新規追加
- `generateSapixSessions`: 夏期講習の教科・テキスト付きセッションを生成
- `getStudyDateFromCode`: 季節講習コード (H:春期 / N:夏期 / F:冬期) をカレンダーから逆引き対応 → 夏期テキスト (N4x-xx) アップロード時に学習日が自動セット
- `sapixHomework.SEASON_DNUMBERS` に `'夏期'` を追加 → 夏期講習中も翌日に「テキスト 復習」家庭学習タスクが自動生成
- WeeklyCalendar: 教科未割当の季節マーカーを綺麗に表示するフォールバック（現状は夏期も実データなので通常表示）

## Test plan

- [ ] カレンダーで夏期講習各日に教科・単元が表示される
- [ ] 夏期テキスト (例 `N41-05.pdf`) をアップロードすると学習日 8/6 が自動セットされる
- [ ] 夏期講習日の翌日に家庭学習タスク（テキスト復習）が生成される

`npm run lint`: 0 warning、`npm run build`: 成功、教科別回数の連番検証済み。


---
_Generated by [Claude Code](https://claude.ai/code/session_0193wWypdTVsezafB6Z53xDP)_