### PR TITLE
fix: AI総評の XSS 脆弱性を修正（HTML エスケープを追加）

### DIFF
--- a/child-learning-app/src/components/ScoreCard.jsx
+++ b/child-learning-app/src/components/ScoreCard.jsx
@@ -4,8 +4,21 @@ import { updateTestScore, getProblemsForTestScore } from '../utils/testScores'
 import { toast } from '../utils/toast'
 import './TestScoreView.css'
 
-function formatReviewHtml(text) {
+// AI総評（Gemini 出力 / Firestore 保存値）は信頼できない入力として扱う。
+// Markdown 変換の前に HTML特殊文字をエスケープすることで、変換後の HTML には
+// この関数自身が挿入する固定タグ (h4/h5/ul/li/strong/br) しか存在しなくなり、
+// スクリプト注入の経路が構造的に閉じる。
+function escapeHtml(text) {
   return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+function formatReviewHtml(text) {
+  return escapeHtml(text)
     .replace(/^## (.+)$/gm, '<h4>$1</h4>')
     .replace(/^### (.+)$/gm, '<h5>$1</h5>')
     .replace(/^- (.+)$/gm, '<li>$1</li>')


### PR DESCRIPTION
## Summary

監査指摘 🔴 #3 の対応。AI総評表示の XSS 脆弱性を修正。

## 問題

`ScoreCard.jsx` の `formatReviewHtml` は Gemini 出力（Firestore 保存の `aiReview`）を正規表現の Markdown 変換だけで `dangerouslySetInnerHTML` に渡していた。出力に `<script>` や `<img onerror=...>` が含まれた場合、そのまま DOM に注入される:

- Gemini へのプロンプトインジェクション（テスト名・メモ経由）で悪意ある HTML を出力させられる可能性
- Firestore 上の `aiReview` フィールド改竄でも成立

## 修正

Markdown 変換の**前に** `escapeHtml` で `& < > " '` をエスケープ。エスケープ後の文字列には `formatReviewHtml` 自身が挿入する固定タグ（h4 / h5 / ul / li / strong / br）しか存在しなくなるため、**注入経路が構造的に閉じる**。

- 外部ライブラリ（DOMPurify 等）は不要 → バンドルサイズへの影響ゼロ
- `dangerouslySetInnerHTML` の使用箇所はアプリ全体でこの 1 箇所のみを確認済み

## 検証（Node で実行済み）

**正常系** — 従来通り変換:
```
## 総評 → <h4>総評</h4>
**算数** → <strong>算数</strong>
- リスト → <ul><li>リスト</li></ul>
```

**攻撃系** — すべてテキストとして無害化:
```
<script>alert(1)</script>   → &lt;script&gt;alert(1)&lt;/script&gt;
``&lt;img src=x onerror=alert(2)&gt;`` → &lt;img src=x onerror=alert(2)&gt;
<b onmouseover=hack()>       → &lt;b onmouseover=hack()&gt;
```

## Test plan

- [ ] 既存の AI総評が従来通り整形表示される（見出し・太字・リスト・改行）
- [ ] 総評の再生成が正常動作
- [ ] （任意）Firestore の aiReview に `<script>alert(1)</script>` を手で入れて、テキスト表示されることを確認

`npm run lint`: 0 warning、`npm run build`: 成功確認済み。


---
_Generated by [Claude Code](https://claude.ai/code/session_0193wWypdTVsezafB6Z53xDP)_