### PR TITLE
test: vitest を導入し中核ロジック 38 件の回帰テストを整備

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,11 @@ jobs:
           cd child-learning-app
           npm ci
 
+      - name: Test
+        run: |
+          cd child-learning-app
+          npm test
+
       - name: Build
         run: |
           cd child-learning-app

--- a/child-learning-app/package-lock.json
+++ b/child-learning-app/package-lock.json
@@ -23,7 +23,8 @@
         "eslint-plugin-react-refresh": "^0.4.24",
         "gh-pages": "^6.3.0",
         "globals": "^16.5.0",
-        "vite": "^7.2.4"
+        "vite": "^7.2.4",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2350,6 +2351,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2394,6 +2402,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -2457,6 +2483,119 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/acorn": {
@@ -2538,6 +2677,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/async": {
@@ -2655,6 +2804,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2814,6 +2973,13 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/esbuild": {
@@ -3054,6 +3220,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3062,6 +3238,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3711,6 +3897,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -3827,6 +4023,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -3929,6 +4139,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pdfjs-dist": {
       "version": "5.4.624",
@@ -4314,6 +4531,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -4333,6 +4557,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -4409,6 +4647,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -4424,6 +4679,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -4613,6 +4878,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/web-vitals": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
@@ -4656,6 +5011,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/child-learning-app/package.json
+++ b/child-learning-app/package.json
@@ -7,6 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "preview": "vite preview",
     "deploy": "gh-pages -d dist"
   },
@@ -26,6 +28,7 @@
     "eslint-plugin-react-refresh": "^0.4.24",
     "gh-pages": "^6.3.0",
     "globals": "^16.5.0",
-    "vite": "^7.2.4"
+    "vite": "^7.2.4",
+    "vitest": "^4.1.10"
   }
 }

--- a/child-learning-app/src/utils/__tests__/sapixHomework.test.js
+++ b/child-learning-app/src/utils/__tests__/sapixHomework.test.js
@@ -1,0 +1,99 @@
+// 家庭学習タスク自動生成のテスト
+//
+// 過去に実際に起きたバグの回帰テストを含む:
+// - 休講・テスト週に家庭学習が完全に空になる（基礎トレも消える）
+// - D15→D16 境界週で回情報が欠落する
+// - 季節講習中にタスクが出ない
+
+import { describe, it, expect } from 'vitest'
+import {
+  generateWeeklyHomework,
+  getHomeworkForDate,
+  getHomeworkByDate,
+} from '../sapixHomework'
+import { parseLocalDate } from '../dateUtils'
+
+describe('毎日タスク（算数 基礎力トレーニング）', () => {
+  it('通常授業週に生成される', () => {
+    const tasks = getHomeworkForDate(parseLocalDate('2026-05-14')) // D11 木曜
+    expect(tasks.some(t => t.studyCategory === 'basic-training' && t.subject === '算数')).toBe(true)
+  })
+
+  it('休講・テスト週でも生成される（2026-05-08 マンスリーテスト日の回帰テスト）', () => {
+    const tasks = getHomeworkForDate(parseLocalDate('2026-05-08'))
+    expect(tasks.some(t => t.studyCategory === 'basic-training')).toBe(true)
+  })
+
+  it('夏期講習期間の谷間（お盆休み等）でも生成される', () => {
+    const tasks = getHomeworkForDate(parseLocalDate('2026-08-12')) // 8/9〜8/14 は講習なし
+    expect(tasks.some(t => t.studyCategory === 'basic-training')).toBe(true)
+  })
+})
+
+describe('通常授業の家庭学習', () => {
+  it('授業当日に A優先度の復習タスクが出る（D11 水曜: 算数）', () => {
+    const tasks = getHomeworkForDate(parseLocalDate('2026-05-13'))
+    const sansuB = tasks.find(t => t.subject === '算数' && t.studyCategory === 'b-review')
+    expect(sansuB).toBeTruthy()
+    expect(sansuB.priority).toBe('A')
+    expect(sansuB.textCode).toMatch(/^41B-/)
+    expect(sansuB.lessonLabel).toBe('第11回')
+  })
+
+  it('回に紐づかないカテゴリ（基礎トレ等）には回情報が付かない', () => {
+    const tasks = getHomeworkForDate(parseLocalDate('2026-05-13'))
+    const basic = tasks.find(t => t.studyCategory === 'basic-training')
+    expect(basic.textCode).toBe('')
+    expect(basic.lessonLabel).toBe('')
+  })
+
+  it('最終授業から7日以上経つと通常タスクは生成されない', () => {
+    // D19 (7/15 水) の 8 日後
+    const tasks = getHomeworkForDate(parseLocalDate('2026-07-23'))
+    expect(tasks.filter(t => t.studyCategory !== 'basic-training')).toHaveLength(0)
+  })
+})
+
+describe('季節講習の家庭学習', () => {
+  it('夏期講習日の翌日に「テキスト 復習」が教科ごとに出る', () => {
+    // 7/30 は 算数1・国語1・社会1 → 7/31 に3教科の復習
+    const tasks = getHomeworkForDate(parseLocalDate('2026-07-31'))
+    const season = tasks.filter(t => t.studyCategory === 'season-review')
+    expect(season.map(t => t.subject).sort()).toEqual(['国語', '社会', '算数'])
+    for (const t of season) {
+      expect(t.classDate).toBe('2026-07-30')
+      expect(t.textCode).toMatch(/^N4\d-/)
+      expect(t.priority).toBe('A')
+    }
+  })
+
+  it('冬期講習日の翌日にも同様に出る', () => {
+    // 12/26 は F41-01(算数)・F42-01(国語)・F44-01(社会)
+    const tasks = getHomeworkForDate(parseLocalDate('2026-12-27'))
+    const season = tasks.filter(t => t.studyCategory === 'season-review')
+    expect(season.map(t => t.subject).sort()).toEqual(['国語', '社会', '算数'])
+  })
+})
+
+describe('タスク ID の一意性', () => {
+  const dates = ['2026-05-13', '2026-07-31', '2026-08-19', '2026-12-27']
+  for (const dateStr of dates) {
+    it(`${dateStr} 起点の生成で ID が重複しない`, () => {
+      const tasks = generateWeeklyHomework(parseLocalDate(dateStr))
+      const ids = tasks.map(t => t.id)
+      expect(new Set(ids).size, `重複: ${ids.filter((id, i) => ids.indexOf(id) !== i).join(', ')}`).toBe(ids.length)
+    })
+  }
+})
+
+describe('getHomeworkByDate', () => {
+  it('指定日数分の日付キーを返し、各日のタスクは dueDate が一致する', () => {
+    const byDate = getHomeworkByDate(parseLocalDate('2026-05-13'), 7)
+    expect(Object.keys(byDate)).toHaveLength(7)
+    for (const [dateStr, tasks] of Object.entries(byDate)) {
+      for (const t of tasks) {
+        expect(t.dueDate, t.id).toBe(dateStr)
+      }
+    }
+  })
+})

--- a/child-learning-app/src/utils/__tests__/sapixSchedule.test.js
+++ b/child-learning-app/src/utils/__tests__/sapixSchedule.test.js
@@ -1,0 +1,152 @@
+// sapixSchedule のカレンダー整合性テスト
+//
+// カレンダー定数（D01〜D36 / 季節講習）はモジュール内 const のため、
+// 公開 API（generateSapixSessions / getStudyDateFromCode）経由で検証する。
+// スケジュール追加・修正時の曜日ミス / コード重複 / 欠番を回帰的に検出する。
+
+import { describe, it, expect } from 'vitest'
+import {
+  generateSapixSessions,
+  getStudyDateFromCode,
+  extractSapixCode,
+  gradeFromCode,
+  SAPIX_SUMMER_4_2026,
+  SAPIX_WINTER_4_2026,
+  SAPIX_SPRING_4_2026,
+} from '../sapixSchedule'
+import { parseLocalDate } from '../dateUtils'
+
+const WED = 3
+const FRI = 5
+
+const sessions = generateSapixSessions()
+const regular = sessions.filter(s => s.dNumber.startsWith('D'))
+const summer = sessions.filter(s => s.dNumber === '夏期')
+const winter = sessions.filter(s => s.dNumber === '冬期')
+const spring = sessions.filter(s => s.dNumber === '春期')
+
+describe('通常授業カレンダー（D01〜D36）', () => {
+  it('算数・理科の授業日はすべて水曜', () => {
+    for (const s of regular.filter(s => s.subject === '算数' || s.subject === '理科')) {
+      expect(parseLocalDate(s.date).getDay(), `${s.dNumber} ${s.textCode} (${s.date})`).toBe(WED)
+    }
+  })
+
+  it('国語・社会の授業日はすべて金曜', () => {
+    for (const s of regular.filter(s => s.subject === '国語' || s.subject === '社会')) {
+      expect(parseLocalDate(s.date).getDay(), `${s.dNumber} ${s.textCode} (${s.date})`).toBe(FRI)
+    }
+  })
+
+  it('全セッションが subject / textCode / name を持つ', () => {
+    for (const s of sessions) {
+      expect(s.subject, `${s.date} ${s.textCode}`).toBeTruthy()
+      expect(s.textCode, `${s.date} ${s.subject}`).toBeTruthy()
+      expect(s.name, `${s.date} ${s.textCode}`).toBeTruthy()
+    }
+  })
+
+  it('セッションは日付昇順にソートされている', () => {
+    for (let i = 1; i < sessions.length; i++) {
+      expect(sessions[i].date >= sessions[i - 1].date).toBe(true)
+    }
+  })
+})
+
+describe('夏期講習カレンダー（4α）', () => {
+  it('全42コマ（算数14 / 国語12 / 理科8 / 社会8）', () => {
+    expect(summer).toHaveLength(42)
+    const count = subj => summer.filter(s => s.subject === subj).length
+    expect(count('算数')).toBe(14)
+    expect(count('国語')).toBe(12)
+    expect(count('理科')).toBe(8)
+    expect(count('社会')).toBe(8)
+  })
+
+  it('テキストコードに重複・欠番がない', () => {
+    const codes = summer.map(s => s.textCode)
+    expect(new Set(codes).size).toBe(codes.length)
+    const nums = prefix =>
+      codes.filter(c => c.startsWith(prefix)).map(c => parseInt(c.slice(4))).sort((a, b) => a - b)
+    expect(nums('N41')).toEqual([...Array(14)].map((_, i) => i + 1))
+    expect(nums('N42')).toEqual([...Array(12)].map((_, i) => i + 1))
+    expect(nums('N43')).toEqual([...Array(8)].map((_, i) => i + 1))
+    expect(nums('N44')).toEqual([...Array(8)].map((_, i) => i + 1))
+  })
+
+  it('日程リスト（全14日）と一致し、各日ちょうど3コマ', () => {
+    const listDates = SAPIX_SUMMER_4_2026.map(d => d.date)
+    expect(listDates).toHaveLength(14)
+    const byDate = {}
+    for (const s of summer) byDate[s.date] = (byDate[s.date] || 0) + 1
+    expect(Object.keys(byDate).sort()).toEqual([...listDates].sort())
+    for (const [date, n] of Object.entries(byDate)) {
+      expect(n, date).toBe(3)
+    }
+  })
+
+  it('日程リストの曜日表記が実際の曜日と一致', () => {
+    const dayNames = ['日', '月', '火', '水', '木', '金', '土']
+    for (const { date, day } of SAPIX_SUMMER_4_2026) {
+      expect(dayNames[parseLocalDate(date).getDay()], date).toBe(day)
+    }
+  })
+})
+
+describe('冬期・春期講習カレンダー', () => {
+  it('冬期: 全6日 × 3コマ = 18セッション、曜日表記が正しい', () => {
+    expect(winter).toHaveLength(18)
+    const dayNames = ['日', '月', '火', '水', '木', '金', '土']
+    for (const { date, day } of SAPIX_WINTER_4_2026) {
+      expect(dayNames[parseLocalDate(date).getDay()], date).toBe(day)
+    }
+  })
+
+  it('春期: 全5日 × 3コマ = 15セッション、曜日表記が正しい', () => {
+    expect(spring).toHaveLength(15)
+    const dayNames = ['日', '月', '火', '水', '木', '金', '土']
+    for (const { date, day } of SAPIX_SPRING_4_2026) {
+      expect(dayNames[parseLocalDate(date).getDay()], date).toBe(day)
+    }
+  })
+})
+
+describe('getStudyDateFromCode', () => {
+  it('通常コード: 算数B・理科は水曜日、国語B・社会は金曜日を返す', () => {
+    expect(getStudyDateFromCode('41A-01')).toBe('2026-02-11')
+    expect(getStudyDateFromCode('41B-25')).toBe('2026-10-14')
+    expect(getStudyDateFromCode('430-20')).toBe('2026-09-02')
+    expect(getStudyDateFromCode('42B-19')).toBe('2026-07-10')
+    expect(getStudyDateFromCode('440-36')).toBe('2027-01-22')
+  })
+
+  it('季節講習コード (H/N/F) はカレンダーから逆引き', () => {
+    expect(getStudyDateFromCode('H41-01')).toBe('2026-03-28')
+    expect(getStudyDateFromCode('N41-05')).toBe('2026-08-06')
+    expect(getStudyDateFromCode('N44-08')).toBe('2026-08-22')
+    expect(getStudyDateFromCode('F41-01')).toBe('2026-12-26')
+    expect(getStudyDateFromCode('F43-03')).toBe('2027-01-05')
+  })
+
+  it('不正・範囲外のコードは null', () => {
+    expect(getStudyDateFromCode('41B-37')).toBeNull()
+    expect(getStudyDateFromCode('41B-00')).toBeNull()
+    expect(getStudyDateFromCode('99X-01')).toBeNull()
+    expect(getStudyDateFromCode('N41-99')).toBeNull()
+  })
+})
+
+describe('extractSapixCode / gradeFromCode', () => {
+  it('ファイル名からコードを抽出できる', () => {
+    expect(extractSapixCode('41B-02.pdf')).toBe('41B-02')
+    expect(extractSapixCode('スキャン_430-15 (1).pdf')).toBe('430-15')
+    expect(extractSapixCode('N41-03.pdf')).toBe('N41-03')
+    expect(extractSapixCode('memo.pdf')).toBeNull()
+  })
+
+  it('コードから学年を推定できる（季節講習は2文字目）', () => {
+    expect(gradeFromCode('41B-02')).toBe('4年生')
+    expect(gradeFromCode('N41-01')).toBe('4年生')
+    expect(gradeFromCode('H51-01')).toBe('5年生')
+  })
+})

--- a/child-learning-app/src/utils/__tests__/testReviews.test.js
+++ b/child-learning-app/src/utils/__tests__/testReviews.test.js
@@ -1,0 +1,96 @@
+// テスト復習スケジュール生成のテスト
+//
+// エビングハウス間隔（翌日/1週間後/1ヶ月後）の日付計算と、
+// 予定テスト（status: 'scheduled'）を除外するガードを回帰的に検証する。
+
+import { describe, it, expect } from 'vitest'
+import {
+  REVIEW_INTERVALS,
+  generateTestReviews,
+  getTestReviewsForDate,
+  getTestReviewsByDate,
+} from '../testReviews'
+import { parseLocalDate } from '../dateUtils'
+
+const completedTest = {
+  id: 'test-1',
+  testName: '5月度マンスリー確認テスト',
+  testDate: '2026-05-08',
+  status: 'completed',
+}
+
+describe('generateTestReviews', () => {
+  it('completed テストには 翌日/1週間後/1ヶ月後 の3件が生成される', () => {
+    const reviews = generateTestReviews([completedTest])
+    expect(reviews).toHaveLength(3)
+    expect(reviews.map(r => r.dueDate).sort()).toEqual([
+      '2026-05-09', // 翌日
+      '2026-05-15', // 1週間後
+      '2026-06-07', // 1ヶ月後 (30日)
+    ])
+  })
+
+  it('id は review-{testId}-{intervalKey} 形式（homeworkDone のキーとして安定）', () => {
+    const reviews = generateTestReviews([completedTest])
+    const ids = reviews.map(r => r.id).sort()
+    expect(ids).toEqual([
+      'review-test-1-next-day',
+      'review-test-1-one-month',
+      'review-test-1-one-week',
+    ])
+  })
+
+  it('scheduled（予定登録のみ・未実施）のテストは復習対象外', () => {
+    const scheduled = { ...completedTest, id: 'test-2', status: 'scheduled' }
+    expect(generateTestReviews([scheduled])).toHaveLength(0)
+  })
+
+  it('status なしの旧データは completed 扱いで復習対象に含める', () => {
+    const legacy = { id: 'test-3', testName: '旧テスト', testDate: '2026-03-08' }
+    expect(generateTestReviews([legacy])).toHaveLength(3)
+  })
+
+  it('testDate や id を欠くデータはスキップ（クラッシュしない）', () => {
+    expect(generateTestReviews([{ id: 'x' }, { testDate: '2026-05-08' }, null, undefined])).toHaveLength(0)
+    expect(generateTestReviews([{ id: 'y', testDate: 'invalid-date' }])).toHaveLength(0)
+  })
+
+  it('複数テストの復習が混在生成される', () => {
+    const tests = [
+      completedTest,
+      { id: 'test-4', testName: '組分け', testDate: '2026-06-28' },
+      { id: 'test-5', testName: '予定', testDate: '2026-07-17', status: 'scheduled' },
+    ]
+    const reviews = generateTestReviews(tests)
+    expect(reviews).toHaveLength(6) // completed 2件 × 3 interval（scheduled は除外）
+  })
+})
+
+describe('getTestReviewsForDate', () => {
+  it('dueDate が一致する復習だけを返す', () => {
+    const reviews = getTestReviewsForDate([completedTest], parseLocalDate('2026-05-09'))
+    expect(reviews).toHaveLength(1)
+    expect(reviews[0].intervalKey).toBe('next-day')
+    expect(reviews[0].testName).toBe('5月度マンスリー確認テスト')
+  })
+
+  it('該当なしの日は空配列', () => {
+    expect(getTestReviewsForDate([completedTest], parseLocalDate('2026-05-10'))).toHaveLength(0)
+  })
+})
+
+describe('getTestReviewsByDate', () => {
+  it('指定日数分の日付キーを持ち、該当日に復習が入る', () => {
+    const byDate = getTestReviewsByDate([completedTest], parseLocalDate('2026-05-09'), 7)
+    expect(Object.keys(byDate)).toHaveLength(7)
+    expect(byDate['2026-05-09']).toHaveLength(1) // 翌日復習
+    expect(byDate['2026-05-15']).toHaveLength(1) // 1週間後復習
+    expect(byDate['2026-05-10']).toHaveLength(0)
+  })
+})
+
+describe('REVIEW_INTERVALS 定義', () => {
+  it('翌日(1) / 1週間後(7) / 1ヶ月後(30) の3段階', () => {
+    expect(REVIEW_INTERVALS.map(i => i.daysAfter)).toEqual([1, 7, 30])
+  })
+})


### PR DESCRIPTION
## Summary

監査指摘 #4 の対応。**自動テストゼロ**の状態から、vitest を導入して中核ロジック **38 テスト** を整備。CI（deploy.yml）にもテストステップを追加し、テスト失敗時はデプロイが中断される。

## テスト対象（3 ファイル / 38 tests）

### `sapixSchedule.test.js` — カレンダー整合性
- D01〜D36 全授業日の曜日整合（算数・理科=水曜、国語・社会=金曜）— 金曜先行の逆転週も含めて機械検証
- 夏期講習 4α: 42コマ / 教科別回数（算数14・国語12・理科8・社会8）/ 連番の欠番・重複なし / 日程リストと一致
- 冬期(18セッション)・春期(15セッション)と曜日表記の一致
- `getStudyDateFromCode`: 通常コード / 季節コード (H/N/F) 逆引き / 不正コードで null
- `extractSapixCode` / `gradeFromCode`

### `testReviews.test.js` — テスト復習スケジュール
- 翌日 / 1週間後 / 1ヶ月後の日付計算
- **scheduled（予定）テストの除外ガード（PR #388 の回帰テスト）**
- status なし旧データの後方互換（completed 扱い）
- 不正データ（testDate 欠落・invalid date・null）でクラッシュしない

### `sapixHomework.test.js` — 家庭学習生成
- **基礎力トレーニングが休講・テスト週・講習谷間でも毎日出る（2026-05-08 バグの回帰テスト）**
- 授業当日の復習タスクと回情報（第N回）付与 / 回に紐づかないカテゴリには付かない
- 季節講習翌日の「テキスト 復習」生成（夏期・冬期）
- タスク ID の一意性（4 起点日で検証）

## インフラ変更

- `package.json`: `"test": "vitest run"` / `"test:watch": "vitest"` を追加、vitest を devDependency に
- `.github/workflows/deploy.yml`: ビルド前に `npm test` を実行

## 実行結果

```
Test Files  3 passed (3)
     Tests  38 passed (38)
  Duration  362ms
```

`npm run lint`: 0 warning、`npm run build`: 成功。

## 今後の拡張余地

- `ScoreCard.formatReviewHtml`（XSS エスケープ）のテスト化には関数の別ファイル切り出しが必要（コンポーネント経由だと firebase import が絡むため）— 別 PR で
- Firestore 連携部（testScores / problems / lessonLogs）はエミュレータ導入が必要 — 必要になったら検討


---
_Generated by [Claude Code](https://claude.ai/code/session_0193wWypdTVsezafB6Z53xDP)_