### PR TITLE
perf: バンドルを分割し初回ロードを約4割削減（1.26MB → 725KB）

### DIFF
--- a/child-learning-app/src/App.jsx
+++ b/child-learning-app/src/App.jsx
@@ -1,15 +1,19 @@
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef, useCallback, lazy, Suspense } from 'react'
 import './App.css'
 import './utils/toast.css'
 import Auth from './components/Auth'
 import TodayAndWeekView from './components/TodayAndWeekView'
 import TaskForm from './components/TaskForm'
 import ScheduleView from './components/ScheduleView'
-import UnitAnalysisView from './components/UnitAnalysisView'
-import PastPaperView from './components/PastPaperView'
-import TestScoreView from './components/TestScoreView'
-import GradesView from './components/GradesView'
-import SapixTextView from './components/SapixTextView'
+import Loading from './components/Loading'
+
+// タブビューは初回表示に不要なので遅延ロード（バンドル分割）。
+// デフォルトの schedule ビュー（TodayAndWeekView + ScheduleView）だけ即時ロード。
+const UnitAnalysisView = lazy(() => import('./components/UnitAnalysisView'))
+const PastPaperView = lazy(() => import('./components/PastPaperView'))
+const TestScoreView = lazy(() => import('./components/TestScoreView'))
+const GradesView = lazy(() => import('./components/GradesView'))
+const SapixTextView = lazy(() => import('./components/SapixTextView'))
 import {
   addTaskToFirestore,
   updateTaskInFirestore,
@@ -358,37 +362,41 @@ function App() {
             onTestClick={handleTestClick}
             userId={user.uid}
           />
-        ) : view === 'dashboard' ? (
-          <UnitAnalysisView
-            tasks={tasks}
-            sapixTexts={sapixTexts}
-            userId={user.uid}
-          />
-        ) : view === 'pastpaper' ? (
-          <PastPaperView
-            tasks={tasks}
-            user={user}
-            customUnits={customUnits}
-            onAddTask={addTask}
-            onUpdateTask={updateTask}
-            onDeleteTask={deleteTask}
-          />
-        ) : view === 'grades' ? (
-          <GradesView
-            user={user}
-          />
-        ) : view === 'testscore' ? (
-          <TestScoreView
-            user={user}
-            initialTestId={pendingTestId}
-            onConsumeInitialTestId={consumeInitialTestId}
-            sapixTexts={sapixTexts}
-          />
-        ) : view === 'sapixtext' ? (
-          <SapixTextView
-            user={user}
-          />
-        ) : null}
+        ) : (
+          <Suspense fallback={<Loading message="読み込み中..." />}>
+            {view === 'dashboard' ? (
+              <UnitAnalysisView
+                tasks={tasks}
+                sapixTexts={sapixTexts}
+                userId={user.uid}
+              />
+            ) : view === 'pastpaper' ? (
+              <PastPaperView
+                tasks={tasks}
+                user={user}
+                customUnits={customUnits}
+                onAddTask={addTask}
+                onUpdateTask={updateTask}
+                onDeleteTask={deleteTask}
+              />
+            ) : view === 'grades' ? (
+              <GradesView
+                user={user}
+              />
+            ) : view === 'testscore' ? (
+              <TestScoreView
+                user={user}
+                initialTestId={pendingTestId}
+                onConsumeInitialTestId={consumeInitialTestId}
+                sapixTexts={sapixTexts}
+              />
+            ) : view === 'sapixtext' ? (
+              <SapixTextView
+                user={user}
+              />
+            ) : null}
+          </Suspense>
+        )}
           </>
         )}
 

--- a/child-learning-app/src/components/ProblemClipList.jsx
+++ b/child-learning-app/src/components/ProblemClipList.jsx
@@ -5,7 +5,7 @@
 //   'test'     — テスト分析タブ (TestScoreView)
 //   'pastPaper' — 過去問タブ (PastPaperView)
 
-import { useState, useMemo } from 'react'
+import { useState, useMemo, lazy, Suspense } from 'react'
 import { createPortal } from 'react-dom'
 import { nowISO } from '../utils/dateUtils'
 import {
@@ -20,8 +20,11 @@ import { getStaticMasterUnits } from '../utils/importMasterUnits'
 import { toast } from '../utils/toast'
 import { LABELS, TOAST } from '../utils/messages'
 import UnitTagPicker from './UnitTagPicker'
-import PdfCropper from './PdfCropper'
 import './ProblemClipList.css'
+
+// PdfCropper は pdfjs-dist（約400KB）を含むため、切り出しモーダルを
+// 開くまでロードしない（バンドル分割）
+const PdfCropper = lazy(() => import('./PdfCropper'))
 
 const DIFFICULTY_LABELS = { 1: '★', 2: '★★', 3: '★★★', 4: '★★★★', 5: '★★★★★' }
 const MISS_TYPE_OPTIONS = [
@@ -911,6 +914,7 @@ export default function ProblemClipList({
 
       {/* PDF切り出し（問題追加フロー用） */}
       {showCropper && (
+        <Suspense fallback={null}>
         <PdfCropper
           key={typeof showCropper === 'string' ? showCropper : 'crop'}
           userId={userId}
@@ -937,10 +941,12 @@ export default function ProblemClipList({
             ) : undefined
           }
         />
+        </Suspense>
       )}
 
       {/* PDF切り出し（詳細モーダルから画像追加） */}
       {detailCropper && (
+        <Suspense fallback={null}>
         <PdfCropper
           key={typeof detailCropper === 'string' ? `detail-${detailCropper}` : 'detail-crop'}
           userId={userId}
@@ -967,6 +973,7 @@ export default function ProblemClipList({
             ) : undefined
           }
         />
+        </Suspense>
       )}
     </div>
   )

--- a/child-learning-app/src/components/TestScoreView.jsx
+++ b/child-learning-app/src/components/TestScoreView.jsx
@@ -1,4 +1,4 @@
-import { useReducer, useEffect, useRef, useState, useMemo } from 'react'
+import { useReducer, useEffect, useRef, useState, useMemo, lazy, Suspense } from 'react'
 import './TestScoreView.css'
 import { getTodayString } from '../utils/dateUtils'
 import {
@@ -20,7 +20,6 @@ import { MAX_FILE_SIZE, SUBJECTS } from '../utils/constants'
 import { toast } from '../utils/toast'
 import { LABELS, TOAST } from '../utils/messages'
 import ProblemClipList from './ProblemClipList'
-import PdfCropper from './PdfCropper'
 import DriveFilePicker from './DriveFilePicker'
 import { uploadPDFToDrive, checkDriveAccess } from '../utils/googleDriveStorage'
 import { refreshGoogleAccessToken } from '../utils/googleAccessToken'
@@ -33,6 +32,9 @@ import {
   getSapixCodesBySubject,
   computeCoveredUnitIds,
 } from '../utils/sapixSchedule'
+
+// PdfCropper は pdfjs-dist（約400KB）を含むため、開くまでロードしない
+const PdfCropper = lazy(() => import('./PdfCropper'))
 
 const EMPTY_ADD_FORM = {
   testName: '',
@@ -1522,6 +1524,7 @@ function TestScoreView({ user, initialTestId, onConsumeInitialTestId, sapixTexts
 
       {/* OCRプレビュー用PDFクロッパー */}
       {ocrCropperTarget != null && (
+        <Suspense fallback={null}>
         <PdfCropper
           key={`ocr-crop-${ocrCropperTarget}`}
           userId={user.uid}
@@ -1558,6 +1561,7 @@ function TestScoreView({ user, initialTestId, onConsumeInitialTestId, sapixTexts
             </div>
           }
         />
+        </Suspense>
       )}
 
       {/* 問題クリップ */}

--- a/child-learning-app/vite.config.js
+++ b/child-learning-app/vite.config.js
@@ -5,4 +5,21 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   base: '/alpha-orbit/',
+  build: {
+    rollupOptions: {
+      output: {
+        // 大きな vendor を分離してキャッシュ効率を上げる。
+        // アプリコードの変更時に firebase / pdfjs の再ダウンロードを避ける。
+        manualChunks: {
+          firebase: [
+            'firebase/app',
+            'firebase/auth',
+            'firebase/firestore',
+            'firebase/storage',
+          ],
+          pdfjs: ['pdfjs-dist'],
+        },
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary

監査指摘 #5（バンドル分割）の対応。単一チャンク 1,257KB (gzip 370KB) を分割し、**初回ロードを約4割削減**。

## Before / After

| | Before | After |
|---|---|---|
| 初回ロード | 1,257KB (gzip 370KB) | **725KB (gzip 221KB)** |
| pdfjs (403KB) | 初回に必ずロード | PDF 切り出しを開くまでロードされない |
| タブビュー | 初回に全部ロード | 各タブ初回オープン時 (13〜37KB each) |
| コード修正時の再DL | 1.26MB 全体 | アプリチャンクのみ (363KB) |

## 変更内容

### 1. `vite.config.js` — vendor 分割
`manualChunks` で firebase (362KB) と pdfjs-dist (403KB) を分離。アプリコード修正時に vendor チャンクのキャッシュが効き続ける。

### 2. `App.jsx` — タブビューの遅延ロード
`UnitAnalysisView` / `PastPaperView` / `TestScoreView` / `GradesView` / `SapixTextView` を `React.lazy` 化。デフォルトの schedule ビュー（TodayAndWeekView + ScheduleView）は即時ロード維持。`Suspense` fallback は既存 `Loading` コンポーネント。

### 3. `PdfCropper` の遅延ロード
pdfjs の唯一の利用箇所である `PdfCropper` を `ProblemClipList` / `TestScoreView` の両方で `lazy` 化。モーダルなので fallback は `null`。

ビルドの 500KB 超警告も解消。

## Test plan

- [ ] 初回表示（今日のタスク + スケジュール）が正常
- [ ] 各タブ（単元マップ / テキスト / テスト / 過去問 / 成績）を開く — 初回に一瞬ローディングが出た後正常表示
- [ ] 問題クリップから PDF 切り出しを開く — クロッパーが正常動作（このとき初めて pdfjs をロード）
- [ ] テストタブの OCR プレビュー用クロッパーも動作
- [ ] DevTools Network タブで pdfjs チャンクがクロッパーを開くまでロードされないことを確認

`npm run lint`: 0 warning、`npm run build`: 成功確認済み。


---
_Generated by [Claude Code](https://claude.ai/code/session_0193wWypdTVsezafB6Z53xDP)_