### PR TITLE
fix: CSS 分割を無効化しテキストタブ等のスタイル欠落を修正

### DIFF
--- a/child-learning-app/vite.config.js
+++ b/child-learning-app/vite.config.js
@@ -6,6 +6,12 @@ export default defineConfig({
   plugins: [react()],
   base: '/alpha-orbit/',
   build: {
+    // CSS はチャンク分割しない（1ファイルに統合して初回にロード）。
+    // コンポーネント間で CSS クラスを借用している箇所があり
+    // （例: SapixTextView が PastPaperView.css の add-form-* を使用）、
+    // CSS を遅延チャンクに分割するとタブの訪問順によってスタイルが
+    // 欠落するため。CSS 全体は gzip 約30KB と小さく分割の利点も薄い。
+    cssCodeSplit: false,
     rollupOptions: {
       output: {
         // 大きな vendor を分離してキャッシュ効率を上げる。


### PR DESCRIPTION
## Summary

PR #391（バンドル分割）の副作用で発生した**テキストタブ等の表示崩れ**を修正。

## 原因

JS のチャンク分割に伴い **CSS もチャンクごとに分割**されたが、コンポーネント間で CSS クラスを借用している箇所があった:

- `SapixTextView` は `add-pastpaper-form` / `add-form-field` / `subject-selector-inline` 等を使用
- しかし定義は **`PastPaperView.css` / `TestScoreView.css`** にある
- 過去問・テストタブを開いたことがない状態でテキストタブを開くと、借用先 CSS が未ロード → 科目タブが縦並び、フォーム・ボタンが未スタイルになる

分割前は全 CSS が 1 ファイルだったため顕在化していなかった。

## 修正

`vite.config.js` に `build.cssCodeSplit: false` を設定。

- CSS は従来通り **1 ファイル（gzip 約30KB）** に統合し、`index.html` から初回ロード
- **JS のチャンク分割（firebase / pdfjs / タブ別 lazy）はそのまま維持** — PR #391 の初回ロード削減効果は失われない（CSS は元々小さいため影響は gzip 30KB のみ）

根本対応（借用クラスの共通 CSS への切り出し）は工数が大きいため別課題とする。

## Test plan

- [ ] シークレットウィンドウ等キャッシュなしで開き、**最初にテキストタブを開く** → 科目タブが横並び・フォームが正しくスタイルされる
- [ ] 過去問 / テスト / 成績 / 単元マップの各タブも表示正常
- [ ] PDF 切り出しモーダルのスタイル正常

`npm test`: 38 passed / `npm run lint`: 0 warning / build 成功（style-*.css が index.html から即時ロードされることを確認済み）。


---
_Generated by [Claude Code](https://claude.ai/code/session_0193wWypdTVsezafB6Z53xDP)_