### PR TITLE
feat: 偏差値推移の「各科目」を科目ごとの独立グラフに変更

### DIFF
--- a/child-learning-app/package-lock.json
+++ b/child-learning-app/package-lock.json
@@ -4975,9 +4975,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "license": "Apache-2.0",
       "dependencies": {
         "http-parser-js": ">=0.5.1",

--- a/child-learning-app/src/components/DeviationChart.css
+++ b/child-learning-app/src/components/DeviationChart.css
@@ -72,6 +72,32 @@
   height: auto;
 }
 
+/* 各科目モード — 科目別グラフのグリッド（PC: 2列 / モバイル: 1列） */
+.subject-charts-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+}
+
+.subject-chart-cell {
+  border: 1px solid var(--color-gray-100, #f3f4f6);
+  border-radius: 12px;
+  padding: 12px;
+  background: #fafafa;
+}
+
+.subject-chart-title {
+  margin: 0 0 8px;
+  font-size: 0.9375rem;
+  font-weight: 700;
+}
+
+@media (max-width: 640px) {
+  .subject-charts-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 .chart-legend {
   display: flex;
   gap: 16px;

--- a/child-learning-app/src/components/DeviationChart.jsx
+++ b/child-learning-app/src/components/DeviationChart.jsx
@@ -10,6 +10,98 @@ const MODES = [
 const subjectKeys = ['sansu', 'kokugo', 'rika', 'shakai']
 const subjectLabels = { sansu: '算数', kokugo: '国語', rika: '理科', shakai: '社会' }
 const subjectColors = { sansu: '#ef4444', kokugo: '#10b981', rika: '#3b82f6', shakai: '#f59e0b' }
+const subjectEmojis = { sansu: '🔢', kokugo: '📖', rika: '🔬', shakai: '🌏' }
+
+// ── 単一ライン折れ線グラフ（共通描画）──────────────────────
+// points: [{ val, index }] — index は data 配列上の位置
+// 自身のデータ範囲で Y スケールを計算して 1 本のラインを描く
+function SingleLineChart({ data, points, color, compact = false }) {
+  if (points.length === 0) return null
+
+  const values = points.map(p => p.val)
+  const minVal = Math.floor(Math.min(...values) - 3)
+  const maxVal = Math.ceil(Math.max(...values) + 3)
+  const range = maxVal - minVal || 1
+
+  const width = 600
+  const height = compact ? 240 : 300
+  const padding = { top: 26, right: 20, bottom: compact ? 46 : 60, left: 50 }
+  const chartWidth = width - padding.left - padding.right
+  const chartHeight = height - padding.top - padding.bottom
+
+  const xStep = chartWidth / (data.length - 1 || 1)
+  const getY = (val) => padding.top + chartHeight - ((val - minVal) / range) * chartHeight
+
+  const coords = points.map(p => ({
+    ...p,
+    x: padding.left + p.index * xStep,
+    y: getY(p.val),
+  }))
+
+  const path = coords.length >= 2
+    ? coords.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x} ${p.y}`).join(' ')
+    : ''
+
+  const gridLines = []
+  const gridStep = range > 20 ? 5 : range > 10 ? 2 : 1
+  for (let v = Math.ceil(minVal / gridStep) * gridStep; v <= maxVal; v += gridStep) {
+    gridLines.push(v)
+  }
+
+  const show50Line = minVal < 50 && maxVal > 50
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} className="chart-svg">
+      {/* Grid */}
+      {gridLines.map(v => (
+        <g key={v}>
+          <line
+            x1={padding.left} y1={getY(v)}
+            x2={width - padding.right} y2={getY(v)}
+            stroke={v === 50 ? '#007AFF' : '#e5e7eb'}
+            strokeWidth={v === 50 ? 1.5 : 0.5}
+            strokeDasharray={v === 50 ? '6,3' : 'none'}
+          />
+          <text x={padding.left - 8} y={getY(v) + 4} textAnchor="end" fontSize="11" fill="#86868b">
+            {v}
+          </text>
+        </g>
+      ))}
+
+      {show50Line && (
+        <text x={width - padding.right + 4} y={getY(50) + 4} fontSize="10" fill="#007AFF" fontWeight="600">
+          50
+        </text>
+      )}
+
+      {/* X axis labels */}
+      {data.map((d, i) => (
+        <text
+          key={i}
+          x={padding.left + i * xStep}
+          y={height - padding.bottom + 20}
+          textAnchor="middle"
+          fontSize="10"
+          fill="#86868b"
+          transform={`rotate(-30, ${padding.left + i * xStep}, ${height - padding.bottom + 20})`}
+        >
+          {new Date(d.testDate).toLocaleDateString('ja-JP', { month: 'short', day: 'numeric' })}
+        </text>
+      ))}
+
+      {/* Line */}
+      {path && <path d={path} fill="none" stroke={color} strokeWidth={2.5} />}
+      {coords.map((p, i) => (
+        <g key={i}>
+          <circle cx={p.x} cy={p.y} r="5" fill="white" stroke={color} strokeWidth="2" />
+          <text x={p.x} y={p.y - 10} textAnchor="middle" fontSize="10" fill={color} fontWeight="600">
+            {p.val}
+          </text>
+        </g>
+      ))}
+    </svg>
+  )
+}
 
 function DeviationChart({ data }) {
   const [mode, setMode] = useState(null)
@@ -25,7 +117,7 @@ function DeviationChart({ data }) {
       else if (key === 'two') val = d.twoSubjects?.deviation ? parseFloat(d.twoSubjects.deviation) : null
       else val = d[key]?.deviation ? parseFloat(d[key].deviation) : null
       if (val !== null && !isNaN(val)) {
-        points.push({ x: 0, y: 0, val, index: i })
+        points.push({ val, index: i })
       }
     })
     return points
@@ -42,91 +134,10 @@ function DeviationChart({ data }) {
   const effectiveMode = mode ||
     (fourLine.length > 0 ? 'four' : twoLine.length > 0 ? 'two' : hasSubjects ? 'subjects' : 'four')
 
-  // 全モードの値を集めてスケール用に使う
-  const allValues = [
-    ...fourLine.map(p => p.val),
-    ...twoLine.map(p => p.val),
-    ...subjectKeys.flatMap(key => subjectLines[key].map(p => p.val)),
-  ]
-
-  if (allValues.length === 0) return null
-
-  // モードに応じて表示するラインの値を集める
-  let activeValues = []
-  if (effectiveMode === 'four') {
-    activeValues = fourLine.map(p => p.val)
-  } else if (effectiveMode === 'two') {
-    activeValues = twoLine.map(p => p.val)
-  } else {
-    subjectKeys.forEach(key => {
-      subjectLines[key].forEach(p => activeValues.push(p.val))
-    })
-  }
-
-  const hasActiveData = activeValues.length > 0
-  const scaleValues = hasActiveData ? activeValues : allValues
-  const minVal = Math.floor(Math.min(...scaleValues) - 3)
-  const maxVal = Math.ceil(Math.max(...scaleValues) + 3)
-  const range = maxVal - minVal || 1
-
-  // SVG dimensions
-  const width = 600
-  const height = 300
-  const padding = { top: 30, right: 20, bottom: 60, left: 50 }
-  const chartWidth = width - padding.left - padding.right
-  const chartHeight = height - padding.top - padding.bottom
-
-  const xStep = chartWidth / (data.length - 1 || 1)
-
-  const getY = (val) => padding.top + chartHeight - ((val - minVal) / range) * chartHeight
-
-  // ポイントにx,y座標を設定
-  const setCoords = (points) => {
-    points.forEach(p => {
-      p.x = padding.left + p.index * xStep
-      p.y = getY(p.val)
-    })
-    return points
-  }
-
-  setCoords(fourLine)
-  setCoords(twoLine)
-  subjectKeys.forEach(key => setCoords(subjectLines[key]))
-
-  const toPath = (points) => {
-    if (points.length < 2) return ''
-    return points.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x} ${p.y}`).join(' ')
-  }
-
-  // Y axis grid lines
-  const gridLines = []
-  const gridStep = range > 20 ? 5 : range > 10 ? 2 : 1
-  for (let v = Math.ceil(minVal / gridStep) * gridStep; v <= maxVal; v += gridStep) {
-    gridLines.push(v)
-  }
-
-  const show50Line = minVal < 50 && maxVal > 50
-
-  const renderLine = (points, color, strokeWidth = 2.5, showLabels = true) => {
-    if (points.length < 1) return null
-    return (
-      <g>
-        {points.length >= 2 && (
-          <path d={toPath(points)} fill="none" stroke={color} strokeWidth={strokeWidth} />
-        )}
-        {points.map((p, i) => (
-          <g key={i}>
-            <circle cx={p.x} cy={p.y} r="5" fill="white" stroke={color} strokeWidth="2" />
-            {showLabels && (
-              <text x={p.x} y={p.y - 10} textAnchor="middle" fontSize="10" fill={color} fontWeight="600">
-                {p.val}
-              </text>
-            )}
-          </g>
-        ))}
-      </g>
-    )
-  }
+  const hasActiveData =
+    effectiveMode === 'four' ? fourLine.length > 0 :
+    effectiveMode === 'two' ? twoLine.length > 0 :
+    hasSubjects
 
   return (
     <div className="deviation-chart">
@@ -147,83 +158,48 @@ function DeviationChart({ data }) {
 
       {!hasActiveData ? (
         <div className="chart-no-data">このモードのデータはありません</div>
+      ) : effectiveMode === 'subjects' ? (
+        /* 各科目 — 科目ごとに独立したグラフを並べる */
+        <div className="subject-charts-grid">
+          {subjectKeys.map(key => {
+            if (subjectLines[key].length < 1) return null
+            return (
+              <div key={key} className="subject-chart-cell">
+                <h4 className="subject-chart-title" style={{ color: subjectColors[key] }}>
+                  {subjectEmojis[key]} {subjectLabels[key]}
+                </h4>
+                <div className="chart-wrapper">
+                  <SingleLineChart
+                    data={data}
+                    points={subjectLines[key]}
+                    color={subjectColors[key]}
+                    compact
+                  />
+                </div>
+              </div>
+            )
+          })}
+        </div>
       ) : (
-      <>
-      <div className="chart-wrapper">
-        <svg viewBox={`0 0 ${width} ${height}`} className="chart-svg">
-          {/* Grid */}
-          {gridLines.map(v => (
-            <g key={v}>
-              <line
-                x1={padding.left} y1={getY(v)}
-                x2={width - padding.right} y2={getY(v)}
-                stroke={v === 50 ? '#007AFF' : '#e5e7eb'}
-                strokeWidth={v === 50 ? 1.5 : 0.5}
-                strokeDasharray={v === 50 ? '6,3' : 'none'}
+        /* 4科目 / 2科目 — 従来通り1つの大きなグラフ */
+        <>
+          <div className="chart-wrapper">
+            <SingleLineChart
+              data={data}
+              points={effectiveMode === 'four' ? fourLine : twoLine}
+              color={effectiveMode === 'four' ? '#3b82f6' : '#10b981'}
+            />
+          </div>
+          <div className="chart-legend">
+            <div className="legend-item">
+              <span
+                className="legend-color"
+                style={{ background: effectiveMode === 'four' ? '#3b82f6' : '#10b981' }}
               />
-              <text x={padding.left - 8} y={getY(v) + 4} textAnchor="end" fontSize="11" fill="#86868b">
-                {v}
-              </text>
-            </g>
-          ))}
-
-          {show50Line && (
-            <text x={width - padding.right + 4} y={getY(50) + 4} fontSize="10" fill="#007AFF" fontWeight="600">
-              50
-            </text>
-          )}
-
-          {/* X axis labels */}
-          {data.map((d, i) => (
-            <text
-              key={i}
-              x={padding.left + i * xStep}
-              y={height - padding.bottom + 20}
-              textAnchor="middle"
-              fontSize="10"
-              fill="#86868b"
-              transform={`rotate(-30, ${padding.left + i * xStep}, ${height - padding.bottom + 20})`}
-            >
-              {new Date(d.testDate).toLocaleDateString('ja-JP', { month: 'short', day: 'numeric' })}
-            </text>
-          ))}
-
-          {/* Lines based on mode */}
-          {effectiveMode === 'four' && renderLine(fourLine, '#3b82f6')}
-          {effectiveMode === 'two' && renderLine(twoLine, '#10b981')}
-          {effectiveMode === 'subjects' && subjectKeys.map(key => (
-            <g key={key}>
-              {renderLine(subjectLines[key], subjectColors[key], 2)}
-            </g>
-          ))}
-        </svg>
-      </div>
-
-      {/* 凡例 */}
-      <div className="chart-legend">
-        {effectiveMode === 'four' && fourLine.length > 0 && (
-          <div className="legend-item">
-            <span className="legend-color" style={{ background: '#3b82f6' }} />
-            <span>4科目</span>
-          </div>
-        )}
-        {effectiveMode === 'two' && twoLine.length > 0 && (
-          <div className="legend-item">
-            <span className="legend-color" style={{ background: '#10b981' }} />
-            <span>2科目</span>
-          </div>
-        )}
-        {effectiveMode === 'subjects' && subjectKeys.map(key => {
-          if (subjectLines[key].length < 1) return null
-          return (
-            <div key={key} className="legend-item">
-              <span className="legend-color" style={{ background: subjectColors[key] }} />
-              <span>{subjectLabels[key]}</span>
+              <span>{effectiveMode === 'four' ? '4科目' : '2科目'}</span>
             </div>
-          )
-        })}
-      </div>
-      </>
+          </div>
+        </>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary

成績タブの偏差値推移グラフで、「各科目」モードを **4教科重ね描き → 科目ごとの独立グラフ** に変更。

## Before / After

| | Before | After |
|---|---|---|
| 各科目モード | 1つのグラフに4本の線が交差 | 科目ごとに独立したグラフ（PC: 2×2 / モバイル: 縦1列） |
| Yスケール | 4教科共通 | **各科目が自分のデータ範囲でスケール** → 推移の起伏が見やすい |
| 凡例 | 4色の凡例 | 各グラフに絵文字＋科目名タイトル（科目色）で不要に |

4科目 / 2科目モードは従来通り1つの大きなグラフのまま。

## 実装

- `DeviationChart.jsx`: 単一ライン描画を `SingleLineChart` コンポーネントとして共通化（4科目/2科目モードも同じ描画関数を使用するリファクタ込み）
- 偏差値50の基準線・日付ラベル・値ラベルは各ミニグラフにも従来通り表示
- `DeviationChart.css`: `.subject-charts-grid`（2列グリッド、640px 以下で1列）追加

## その他

npm audit で新たに公開されていた `websocket-driver` の critical 1 件を `npm audit fix` で解消（lock ファイルのみ）。

## Test plan

- [ ] 成績タブ → 偏差値推移 → 「各科目」タブ: 科目ごとのグラフが 2×2 で表示される
- [ ] データのない科目のグラフは表示されない
- [ ] 「4科目」「2科目」タブは従来通り
- [ ] モバイル幅で縦1列になる

`npm test`: 38 passed / `npm run lint`: 0 warning / build 成功。


---
_Generated by [Claude Code](https://claude.ai/code/session_0193wWypdTVsezafB6Z53xDP)_