### PR TITLE
feat: 各科目グラフをグリッドからトグル切替に変更

### DIFF
--- a/child-learning-app/src/components/DeviationChart.css
+++ b/child-learning-app/src/components/DeviationChart.css
@@ -72,30 +72,41 @@
   height: auto;
 }
 
-/* 各科目モード — 科目別グラフのグリッド（PC: 2列 / モバイル: 1列） */
-.subject-charts-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 16px;
+/* 各科目モード — 科目切替トグル */
+.subject-toggle {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-bottom: 12px;
 }
 
-.subject-chart-cell {
-  border: 1px solid var(--color-gray-100, #f3f4f6);
-  border-radius: 12px;
-  padding: 12px;
-  background: #fafafa;
+.subject-toggle-btn {
+  padding: 6px 16px;
+  border: 1.5px solid var(--color-gray-200, #e5e7eb);
+  border-radius: 8px;
+  background: white;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-gray-500, #6b7280);
+  cursor: pointer;
+  transition: all 0.15s;
 }
 
-.subject-chart-title {
-  margin: 0 0 8px;
-  font-size: 0.9375rem;
-  font-weight: 700;
+.subject-toggle-btn:hover:not(:disabled) {
+  border-color: var(--subject-color);
+  color: var(--subject-color);
 }
 
-@media (max-width: 640px) {
-  .subject-charts-grid {
-    grid-template-columns: 1fr;
-  }
+.subject-toggle-btn.active {
+  background: var(--subject-color);
+  border-color: var(--subject-color);
+  color: white;
+}
+
+.subject-toggle-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 .chart-legend {

--- a/child-learning-app/src/components/DeviationChart.jsx
+++ b/child-learning-app/src/components/DeviationChart.jsx
@@ -15,7 +15,7 @@ const subjectEmojis = { sansu: '🔢', kokugo: '📖', rika: '🔬', shakai: '�
 // ── 単一ライン折れ線グラフ（共通描画）──────────────────────
 // points: [{ val, index }] — index は data 配列上の位置
 // 自身のデータ範囲で Y スケールを計算して 1 本のラインを描く
-function SingleLineChart({ data, points, color, compact = false }) {
+function SingleLineChart({ data, points, color }) {
   if (points.length === 0) return null
 
   const values = points.map(p => p.val)
@@ -24,8 +24,8 @@ function SingleLineChart({ data, points, color, compact = false }) {
   const range = maxVal - minVal || 1
 
   const width = 600
-  const height = compact ? 240 : 300
-  const padding = { top: 26, right: 20, bottom: compact ? 46 : 60, left: 50 }
+  const height = 300
+  const padding = { top: 26, right: 20, bottom: 60, left: 50 }
   const chartWidth = width - padding.left - padding.right
   const chartHeight = height - padding.top - padding.bottom
 
@@ -105,6 +105,7 @@ function SingleLineChart({ data, points, color, compact = false }) {
 
 function DeviationChart({ data }) {
   const [mode, setMode] = useState(null)
+  const [selectedSubject, setSelectedSubject] = useState(null)
 
   if (!data || data.length < 1) return null
 
@@ -159,27 +160,41 @@ function DeviationChart({ data }) {
       {!hasActiveData ? (
         <div className="chart-no-data">このモードのデータはありません</div>
       ) : effectiveMode === 'subjects' ? (
-        /* 各科目 — 科目ごとに独立したグラフを並べる */
-        <div className="subject-charts-grid">
-          {subjectKeys.map(key => {
-            if (subjectLines[key].length < 1) return null
-            return (
-              <div key={key} className="subject-chart-cell">
-                <h4 className="subject-chart-title" style={{ color: subjectColors[key] }}>
-                  {subjectEmojis[key]} {subjectLabels[key]}
-                </h4>
-                <div className="chart-wrapper">
-                  <SingleLineChart
-                    data={data}
-                    points={subjectLines[key]}
-                    color={subjectColors[key]}
-                    compact
-                  />
-                </div>
+        /* 各科目 — トグルで科目を選び、通常サイズのグラフ1つで表示 */
+        (() => {
+          // 選択中の科目（未選択・データなしの場合はデータのある最初の科目）
+          const activeSubject =
+            selectedSubject && subjectLines[selectedSubject].length > 0
+              ? selectedSubject
+              : subjectKeys.find(key => subjectLines[key].length > 0)
+          return (
+            <>
+              <div className="subject-toggle">
+                {subjectKeys.map(key => {
+                  const hasData = subjectLines[key].length > 0
+                  return (
+                    <button
+                      key={key}
+                      className={`subject-toggle-btn ${activeSubject === key ? 'active' : ''}`}
+                      style={{ '--subject-color': subjectColors[key] }}
+                      disabled={!hasData}
+                      onClick={() => setSelectedSubject(key)}
+                    >
+                      {subjectEmojis[key]} {subjectLabels[key]}
+                    </button>
+                  )
+                })}
               </div>
-            )
-          })}
-        </div>
+              <div className="chart-wrapper">
+                <SingleLineChart
+                  data={data}
+                  points={subjectLines[activeSubject]}
+                  color={subjectColors[activeSubject]}
+                />
+              </div>
+            </>
+          )
+        })()
       ) : (
         /* 4科目 / 2科目 — 従来通り1つの大きなグラフ */
         <>


### PR DESCRIPTION
レビューフィードバック対応。2×2 グリッドの小さいグラフではなく、
グラフは従来と同じ大きさ 1 つのまま、科目トグルボタン
（🔢算数 / 📖国語 / 🔬理科 / 🌏社会）で表示科目を切り替える形式に。

- 選択中の科目は科目色で塗り、データのない科目は disabled
- 初期表示はデータのある最初の科目
- SingleLineChart の compact パラメータは不要になったため削除
- CSS: subject-charts-grid を撤去し subject-toggle スタイルを追加

npm test: 38 passed / lint 0 / ビルド成功。